### PR TITLE
Checks if the attribute 'code' exists, if not, consider 0 as default value.

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/DefaultExceptionResolver.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/DefaultExceptionResolver.java
@@ -76,12 +76,12 @@ public class DefaultExceptionResolver
 	 * @return the exception
 	 */
 	private JsonRpcClientException createJsonRpcClientException(ObjectNode errorObject) {
+		int code = errorObject.has("code") ? errorObject.get("code").asInt() : 0;
 		return new JsonRpcClientException(
-			errorObject.get("code").asInt(),
+			code,
 			errorObject.get("message").asText(),
 			errorObject.get("data"));
 	}
-
 
 	/**
 	 * Attempts to create an {@link Throwable} of the given type


### PR DESCRIPTION
I use the jsonrpc4j as a client library, and other library to server, written in .Net. This other library don't support 'code' attribute on error messages. I suggest this change to make it compatible with servers that don't return this attribute.
