### PR TITLE
Wrap null argument lists in an Object[]

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/ReflectionUtil.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ReflectionUtil.java
@@ -238,7 +238,7 @@ public abstract class ReflectionUtil {
 			}
 			return namedParams;
 		} else {
-			return arguments;
+			return arguments != null ? arguments : new Object[] { null };
 		}
 	}
 


### PR DESCRIPTION
Allow client interface methods to be declared with no parameters, by
creating a null Object array.
