### PR TITLE
small fix not to pass a null in the Object[] in the ReflectionUtils

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/ReflectionUtil.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ReflectionUtil.java
@@ -238,7 +238,7 @@ public abstract class ReflectionUtil {
 			}
 			return namedParams;
 		} else {
-			return arguments != null ? arguments : new Object[] { null };
+			return arguments != null ? arguments : new Object[] { };
 		}
 	}
 


### PR DESCRIPTION
A number of automated tests seem to fail in relation to pull-request #43.  If I remove the null, the tests will run fine again; I am not able to see a reason for the null value in the array.
