### PR TITLE
Fix for the non-http createClientProxy to respect @JsonRpcMethod annotation

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/ProxyUtil.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ProxyUtil.java
@@ -182,8 +182,15 @@ public abstract class ProxyUtil {
 						return proxyObjectMethods(method, proxy, args);
 					}
 					Object arguments = ReflectionUtil.parseArguments(method, args, useNamedParams);
+
+					String methodName=method.getName();
+					JsonRpcMethod methodAnnotation = method.getAnnotation(JsonRpcMethod.class);
+		            if (methodAnnotation!=null && methodAnnotation.value()!=null) {
+		            	methodName=methodAnnotation.value();
+		            }
+
 					return client.invokeAndReadResponse(
-						method.getName(), arguments, method.getGenericReturnType(), ops, ips);
+						methodName, arguments, method.getGenericReturnType(), ops, ips);
 				}
 			});
 	}


### PR DESCRIPTION
Currently, only the createClientProxy method accepting a JsonRpcHttpClient respects the @JsonRpcMethod annotation on a method. This small fix gives both versions of the methods the same behaviour again.