### PR TITLE
remove unnecessary exceptions are thrown

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/spring/JsonProxyFactoryBean.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/JsonProxyFactoryBean.java
@@ -133,8 +133,7 @@ public class JsonProxyFactoryBean
 	/**
 	 * {@inheritDoc}
 	 */
-	public Object getObject()
-		throws Exception {
+	public Object getObject() {
 		return proxyObject;
 	}
 


### PR DESCRIPTION
```java
JsonProxyFactoryBean jsonProxyFactoryBean = new JsonProxyFactoryBean();
        jsonProxyFactoryBean.setServiceUrl(url.toIdentityString());
        jsonProxyFactoryBean.setServiceInterface(serviceType);

        jsonProxyFactoryBean.afterPropertiesSet();
        try {
            return (T) jsonProxyFactoryBean.getObject();   //Maybe I don't really need catch
        } catch (Exception e) {
            throw new RpcException(e);
        }
```