### PR TITLE
Upgrade to Jackson 2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<spring.version>3.1.2.RELEASE</spring.version>
-		<jackson.version>2.0.2</jackson.version>
+		<jackson.version>2.5.2</jackson.version>
 		<jdk.version>1.5</jdk.version>
 	</properties>
 

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -402,7 +402,7 @@ public class JsonRpcClient {
 					JsonNode argNode = mapper.valueToTree(arg);
 					paramsNode.add(argNode);
 				}
-				request.put("params", paramsNode);
+				request.set("params", paramsNode);
 			}
 		
 		// collection args
@@ -416,18 +416,18 @@ public class JsonRpcClient {
 					JsonNode argNode = mapper.valueToTree(arg);
 					paramsNode.add(argNode);
 				}
-				request.put("params", paramsNode);
+				request.set("params", paramsNode);
 			}
 			
 		// map args
 		} else if (arguments!=null && Map.class.isInstance(arguments)) {
 			if (!Map.class.cast(arguments).isEmpty()) {
-				request.put("params", mapper.valueToTree(arguments));
+				request.set("params", mapper.valueToTree(arguments));
 			}
 
 		// other args
 		} else if (arguments!=null) {
-			request.put("params", mapper.valueToTree(arguments));
+			request.set("params", mapper.valueToTree(arguments));
 		}
 
 		// show to listener

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpAsyncClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpAsyncClient.java
@@ -401,25 +401,25 @@ public class JsonRpcHttpAsyncClient {
 		if (arguments != null && arguments.getClass().isArray()) {
 			Object[] args = Object[].class.cast(arguments);
 			if (args.length > 0) {
-				request.put("params",
+				request.set("params",
 						mapper.valueToTree(Object[].class.cast(arguments)));
 			}
 
 			// collection args
 		} else if (arguments != null && Collection.class.isInstance(arguments)) {
 			if (!Collection.class.cast(arguments).isEmpty()) {
-				request.put("params", mapper.valueToTree(arguments));
+				request.set("params", mapper.valueToTree(arguments));
 			}
 
 			// map args
 		} else if (arguments != null && Map.class.isInstance(arguments)) {
 			if (!Map.class.cast(arguments).isEmpty()) {
-				request.put("params", mapper.valueToTree(arguments));
+				request.set("params", mapper.valueToTree(arguments));
 			}
 
 			// other args
 		} else if (arguments != null) {
-			request.put("params", mapper.valueToTree(arguments));
+			request.set("params", mapper.valueToTree(arguments));
 		}
 
 		if (LOGGER.isLoggable(Level.FINE)) {

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -577,7 +577,7 @@ public class JsonRpcServer {
 		error.put("code", code);
 		error.put("message", message);
 		if (data!=null) {
-			error.put("data",  mapper.valueToTree(data));
+			error.set("data",  mapper.valueToTree(data));
 		}
 		response.put("jsonrpc", jsonRpc);
 		if (Integer.class.isInstance(id)) {
@@ -593,7 +593,7 @@ public class JsonRpcServer {
 		} else {
 			response.put("id", String.class.cast(id));
 		}
-		response.put("error", error);
+		response.set("error", error);
 		return response;
 	}
 
@@ -620,7 +620,7 @@ public class JsonRpcServer {
 		} else {
 			response.put("id", String.class.cast(id));
 		}
-		response.put("result", result);
+		response.set("result", result);
 		return response;
 	}
 


### PR DESCRIPTION
Currently used Jackson version is fairly old while there's no real problem with it, it's just a little annoying when you use projects like dropwizard that currently use Jackson 2.5.1 (2.5.2 incoming) and you either see old version dependencies or have to use exclusions to keep your distributions tidy.

This patch doesn't change the functionality in any meaningful way, the only changes are the version bump in pom.xml and some related code that was deprecated in newer version of Jackson.