### PR TITLE
Minor JavaDoc fixes in IJsonRpcClient.java

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/IJsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/IJsonRpcClient.java
@@ -36,7 +36,7 @@ public interface IJsonRpcClient {
 	 * Invokes the given method with the given argument.
 	 *
 	 * @param methodName the name of the method to invoke
-	 * @param arguments the arguments to the method
+	 * @param argument the arguments to the method
 	 * @throws Throwable on error
 	 */
 	public void invoke(String methodName, Object argument)
@@ -60,7 +60,7 @@ public interface IJsonRpcClient {
 	 * an object of the given type, or null if void.
 	 *
 	 * @param methodName the name of the method to invoke
-	 * @param arguments the arguments to the method
+	 * @param argument the arguments to the method
 	 * @param returnType the return type
 	 * @param extraHeaders extra headers to add to the request
 	 * @return the return value
@@ -75,7 +75,7 @@ public interface IJsonRpcClient {
 	 *
 	 * @param methodName the name of the method to invoke
 	 * @param argument the arguments to the method
-	 * @param returnType the return type
+	 * @param <T> the return type
 	 * @return the return value
 	 * @throws Throwable on error
 	 */
@@ -87,8 +87,8 @@ public interface IJsonRpcClient {
 	 * an object of the given type, or null if void.
 	 *
 	 * @param methodName the name of the method to invoke
-	 * @param arguments the arguments to the method
-	 * @param returnType the return type
+	 * @param argument the arguments to the method
+	 * @param <T> the return type
 	 * @param extraHeaders extra headers to add to the request
 	 * @return the return value
 	 * @throws Throwable on error

--- a/src/main/java/com/googlecode/jsonrpc4j/IJsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/IJsonRpcClient.java
@@ -36,7 +36,7 @@ public interface IJsonRpcClient {
 	 * Invokes the given method with the given argument.
 	 *
 	 * @param methodName the name of the method to invoke
-	 * @param argument the arguments to the method
+	 * @param argument the argument to the method
 	 * @throws Throwable on error
 	 */
 	public void invoke(String methodName, Object argument)
@@ -75,6 +75,7 @@ public interface IJsonRpcClient {
 	 *
 	 * @param methodName the name of the method to invoke
 	 * @param argument the arguments to the method
+	 * @param clazz the class of the return type
 	 * @param <T> the return type
 	 * @return the return value
 	 * @throws Throwable on error
@@ -88,8 +89,9 @@ public interface IJsonRpcClient {
 	 *
 	 * @param methodName the name of the method to invoke
 	 * @param argument the arguments to the method
-	 * @param <T> the return type
+	 * @param clazz the class of the return type
 	 * @param extraHeaders extra headers to add to the request
+	 * @param <T> the return type
 	 * @return the return value
 	 * @throws Throwable on error
 	 */


### PR DESCRIPTION
Fix minor errors:

`arguments` -> `argument`
`returnType` -> `<T>`
