### PR TITLE
Fix version range import in OSGi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.briandilley.jsonrpc4j</groupId>
 	<artifactId>jsonrpc4j</artifactId>
-	<version>1.2.0-rc1</version>
+	<version>1.2.0-rc1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>JSON-RPC for java</name>
@@ -121,7 +121,7 @@
 				<configuration>
 					<instructions>
 						<!-- javax.servlet 3.0 has its packages  exported both as 2.6 and 3.0, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=360245-->
-						<Import-Package>javax.servlet*;version=[2.6,4),*</Import-Package>
+						<Import-Package>javax.servlet*;version="[2.6,4)",*</Import-Package>
 					</instructions>
 				</configuration>
 				<executions>


### PR DESCRIPTION
Sorry, copy pasted a wrong version from our internal fork.