### PR TITLE
Allow running with old Servlet API specifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,9 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<configuration>
 					<instructions>
-						<!-- javax.servlet 3.0 has its packages  exported both as 2.6 and 3.0, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=360245-->
-						<Import-Package>javax.servlet*;version="[2.6,4)",*</Import-Package>
+						<!-- our limited use of javax.servlet.http package is compatible with all versions, not just 3.x,
+						     despite this is the version we currently depend on at build time -->
+						<Import-Package>javax.servlet*;version=0.0.0,*</Import-Package>
 					</instructions>
 				</configuration>
 				<executions>


### PR DESCRIPTION
Our build time dependency to the javax.servlet.http package is through the 3.1
version of Servlet API. But given the limited usage we make of this package, it
is compatible with all versions. So we put 0.0.0 as version for the imported
package in the OSGi manifest, which means "any version".

Other imported packages have version restriction that look reasonable:
- jackson: we use 2.5.2 at build time, so [2.5,3) range is OK
- spring: we use 3.1.2 at build time, so [3.1,4) range looks good;
someone with better knowledge of API compatibility may suggest we use [3.0,4)
if compatible
- javax.portlet: we use 2.0 at build time, and the classes we use were
introduced in 2.0, so [2.0,3] range is OK