### PR TITLE
AbstractJsonServiceExporter; Adjustment to Handle Exposing Service with no Interface

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
@@ -51,7 +51,15 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 			objectMapper = new ObjectMapper();
 		}
 
-		jsonRpcServer = new JsonRpcServer(objectMapper, getProxyForService(), getServiceInterface());
+		// Create the server.  The 'handler' parameter here is either a proxy or the real instance depending on
+		// the presence or absence of the interface.  This is because it is not possible to create a proxy unless
+		// an interface is specified.
+
+		jsonRpcServer = new JsonRpcServer(
+			objectMapper,
+				null==getServiceInterface() ? getService() : getProxyForService(),
+				getServiceInterface()
+		);
 		jsonRpcServer.setErrorResolver(errorResolver);
 		jsonRpcServer.setBackwardsCompatible(backwardsCompatible);
 		jsonRpcServer.setRethrowExceptions(rethrowExceptions);

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathClientIntegrationTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathClientIntegrationTest.java
@@ -3,6 +3,7 @@ package com.googlecode.jsonrpc4j.spring;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 
+import com.googlecode.jsonrpc4j.spring.service.Service;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathServerIntegrationTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathServerIntegrationTest.java
@@ -23,7 +23,7 @@ public class JsonRpcPathServerIntegrationTest {
     assertNotNull(applicationContext);
 
     {
-      Object bean = applicationContext.getBean("/Service");
+      Object bean = applicationContext.getBean("/TestService");
       assertSame(JsonServiceExporter.class, bean.getClass());
     }
 

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathServerIntegrationTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathServerIntegrationTest.java
@@ -18,10 +18,19 @@ public class JsonRpcPathServerIntegrationTest {
 	@Autowired
 	private ApplicationContext applicationContext;
 
-	@Test
-	public void shouldCreateServiceExporter() {
-		assertNotNull(applicationContext);
-		Object bean = applicationContext.getBean("/TestService");
-		assertSame(JsonServiceExporter.class, bean.getClass());
-	}
+  @Test
+  public void shouldCreateServiceExporter() {
+    assertNotNull(applicationContext);
+
+    {
+      Object bean = applicationContext.getBean("/Service");
+      assertSame(JsonServiceExporter.class, bean.getClass());
+    }
+
+    {
+      Object bean = applicationContext.getBean("/ServiceSansInterface");
+      assertSame(JsonServiceExporter.class, bean.getClass());
+    }
+
+  }
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/Service.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/Service.java
@@ -1,8 +1,0 @@
-package com.googlecode.jsonrpc4j.spring;
-
-import com.googlecode.jsonrpc4j.JsonRpcService;
-
-@JsonRpcService("TestService")
-interface Service {
-
-}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/ServiceImpl.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/ServiceImpl.java
@@ -1,5 +1,0 @@
-package com.googlecode.jsonrpc4j.spring;
-
-class ServiceImpl implements Service {
-
-}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/service/Service.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/service/Service.java
@@ -1,0 +1,8 @@
+package com.googlecode.jsonrpc4j.spring.service;
+
+import com.googlecode.jsonrpc4j.JsonRpcService;
+
+@JsonRpcService("TestService")
+interface Service {
+
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/service/Service.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/service/Service.java
@@ -2,7 +2,7 @@ package com.googlecode.jsonrpc4j.spring.service;
 
 import com.googlecode.jsonrpc4j.JsonRpcService;
 
-@JsonRpcService("Service")
+@JsonRpcService("TestService")
 public interface Service {
 
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/service/Service.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/service/Service.java
@@ -3,6 +3,6 @@ package com.googlecode.jsonrpc4j.spring.service;
 import com.googlecode.jsonrpc4j.JsonRpcService;
 
 @JsonRpcService("TestService")
-interface Service {
+public interface Service {
 
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/service/ServiceImpl.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/service/ServiceImpl.java
@@ -1,0 +1,5 @@
+package com.googlecode.jsonrpc4j.spring.service;
+
+public class ServiceImpl implements Service {
+
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/servicesansinterface/ServiceSansInterfaceImpl.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/servicesansinterface/ServiceSansInterfaceImpl.java
@@ -1,0 +1,14 @@
+package com.googlecode.jsonrpc4j.spring.servicesansinterface;
+
+import com.googlecode.jsonrpc4j.JsonRpcService;
+
+/**
+ * <p>Unlike the {@link com.googlecode.jsonrpc4j.spring.service.Service} /
+ * {@link com.googlecode.jsonrpc4j.spring.service.ServiceImpl} example, this case has no interface
+ * so the bean has the @JsonRpcService directly into the implementation.  This setup worked
+ * in jsonrpc4j 1.1, but failed in 1.2.</p>
+ */
+
+@JsonRpcService("ServiceSansInterface")
+public class ServiceSansInterfaceImpl {
+}

--- a/src/test/resources/clientApplicationContext.xml
+++ b/src/test/resources/clientApplicationContext.xml
@@ -3,8 +3,8 @@
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-    <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcClientProxyCreator"
-          p:baseUrl="http://localhost:8080/the-context/"
-          p:scanPackage="com.googlecode.jsonrpc4j.spring"/>
+  <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcClientProxyCreator"
+    p:baseUrl="http://localhost:8080/the-context/"
+    p:scanPackage="com.googlecode.jsonrpc4j.spring.service" />
 
 </beans>

--- a/src/test/resources/serverApplicationContext.xml
+++ b/src/test/resources/serverApplicationContext.xml
@@ -2,7 +2,8 @@
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-    <bean class="com.googlecode.jsonrpc4j.spring.ServiceImpl"/>
-    <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter"/>
+  <bean class="com.googlecode.jsonrpc4j.spring.service.ServiceImpl" />
+  <bean class="com.googlecode.jsonrpc4j.spring.servicesansinterface.ServiceSansInterfaceImpl" />
+  <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter"/>
 
 </beans>


### PR DESCRIPTION
In version 1.1 of this library it was possible to export a bean (service) that had the \@JsonRpcService annotation directly on the implementation without an interface.  In 1.2 this was no longer possible.  This patch should make that possible again.