### PR TITLE
Allow changes to the parameters before invoking a method.

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/ConvertedParameterTransformer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ConvertedParameterTransformer.java
@@ -1,0 +1,22 @@
+package com.googlecode.jsonrpc4j;
+
+/**
+ * Implementations of this interface are able to transform the converted parameters before a method invocation in the
+ * JSON-RPC service. This allows for mutation of the deserialized arguments before a method invocation or for validation
+ * of the actual argument objects.
+ *
+ * Any exceptions thrown in the {@link ConvertedParameterTransformer#transformConvertedParameters(Object, Object[])}
+ * method, will be returned as an error to the JSON-RPC client.
+ */
+public interface ConvertedParameterTransformer {
+
+	/**
+	 * Returns the parameters that will be passed to the method on invocation.
+	 *
+	 * @param target          optional service name used to locate the target object
+	 *                        to invoke the Method on.
+	 * @param convertedParams the parameters to pass to the method on invocation.
+	 * @return the mutated parameters that will be passed to the method on invocation.
+	 */
+	Object[] transformConvertedParameters(Object target, Object[] convertedParams);
+}

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -82,6 +82,7 @@ public class JsonRpcBasicServer {
 	private RequestInterceptor requestInterceptor = null;
 	private ErrorResolver errorResolver = null;
 	private InvocationListener invocationListener = null;
+	private ConvertedParameterTransformer convertedParameterTransformer = null;
 
 	/**
 	 * Creates the server with the given {@link ObjectMapper} delegating
@@ -388,6 +389,9 @@ public class JsonRpcBasicServer {
 	private JsonNode invoke(Object target, Method method, List<JsonNode> params) throws IOException, IllegalAccessException, InvocationTargetException {
 		logger.debug("Invoking method: {} with args {}", method.getName(), params);
 		Object[] convertedParams = convertJsonToParameters(method, params);
+		if (convertedParameterTransformer != null) {
+			convertedParams = convertedParameterTransformer.transformConvertedParameters(target, convertedParams);
+		}
 		Object result = method.invoke(target, convertedParams);
 		logger.debug("Invoked method: {}, result {}", method.getName(), result);
 		return hasReturnValue(method) ? mapper.valueToTree(result) : null;
@@ -760,6 +764,16 @@ public class JsonRpcBasicServer {
      */
 	public void setHttpStatusCodeProvider(HttpStatusCodeProvider httpStatusCodeProvider) {
 		this.httpStatusCodeProvider = httpStatusCodeProvider;
+	}
+
+	/**
+	 * Sets the {@link ConvertedParameterTransformer} instance that can be
+	 * used to mutate the deserialized arguments passed to the service method during invocation.
+	 *
+	 * @param convertedParameterTransformer the transformer to set
+	 */
+	public void setConvertedParameterTransformer(ConvertedParameterTransformer convertedParameterTransformer) {
+		this.convertedParameterTransformer = convertedParameterTransformer;
 	}
 
 	private static class ErrorObjectWithJsonError {

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
@@ -1,6 +1,7 @@
 package com.googlecode.jsonrpc4j.spring;
 
 import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
+import com.googlecode.jsonrpc4j.ConvertedParameterTransformer;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
@@ -33,6 +34,7 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 	private boolean allowLessParams = false;
 	private InvocationListener invocationListener = null;
 	private HttpStatusCodeProvider httpStatusCodeProvider = null;
+	private ConvertedParameterTransformer convertedParameterTransformer = null;
 
 	/**
 	 * {@inheritDoc}
@@ -61,6 +63,7 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 		jsonRpcServer.setAllowLessParams(allowLessParams);
 		jsonRpcServer.setInvocationListener(invocationListener);
 		jsonRpcServer.setHttpStatusCodeProvider(httpStatusCodeProvider);
+		jsonRpcServer.setConvertedParameterTransformer(convertedParameterTransformer);
 
 		exportService();
 	}
@@ -156,5 +159,12 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 	 */
 	public void setHttpStatusCodeProvider(HttpStatusCodeProvider httpStatusCodeProvider) {
 		this.httpStatusCodeProvider = httpStatusCodeProvider;
+	}
+	/**
+	 *
+	 * @param convertedParameterTransformer the convertedParameterTransformer to set
+	 */
+	public void setConvertedParameterTransformer(ConvertedParameterTransformer convertedParameterTransformer) {
+		this.convertedParameterTransformer = convertedParameterTransformer;
 	}
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static org.springframework.util.ClassUtils.forName;
 import static org.springframework.util.ClassUtils.getAllInterfacesForClass;
 
+import com.googlecode.jsonrpc4j.ConvertedParameterTransformer;
 import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
 import org.apache.logging.log4j.LogManager;
 
@@ -52,6 +53,7 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 	private boolean allowLessParams = false;
 	private InvocationListener invocationListener = null;
 	private HttpStatusCodeProvider httpStatusCodeProvider = null;
+	private ConvertedParameterTransformer convertedParameterTransformer = null;
 
 	/**
 	 * Finds the beans to expose
@@ -147,6 +149,10 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 			builder.addPropertyValue("httpStatusCodeProvider", httpStatusCodeProvider);
 		}
 
+		if (convertedParameterTransformer != null) {
+			builder.addPropertyValue("convertedParameterTransformer", convertedParameterTransformer);
+		}
+
 		builder.addPropertyValue("backwardsCompatible", backwardsCompatible);
 		builder.addPropertyValue("rethrowExceptions", rethrowExceptions);
 		builder.addPropertyValue("allowExtraParams", allowExtraParams);
@@ -238,5 +244,13 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 	 */
 	public void setHttpStatusCodeProvider(HttpStatusCodeProvider httpStatusCodeProvider) {
 		this.httpStatusCodeProvider = httpStatusCodeProvider;
+	}
+
+	/**
+	 *
+	 * @param convertedParameterTransformer the convertedParameterTransformer to set
+	 */
+	public void setConvertedParameterTransformer(ConvertedParameterTransformer convertedParameterTransformer) {
+		this.convertedParameterTransformer = convertedParameterTransformer;
 	}
 }


### PR DESCRIPTION
Thanks for this great project.

This pull request adds an optional parameter transformer and calls it before method invocation. This allows mutating the arguments of a method call. But it could also be used for validation. For example a JSR-303 validator might be injected into the call chain to make invalid requests fail early. 

This is similar to the RequestInterceptor but it operates on de-serialised arguments instead of their JSON representation.