### PR TITLE
Adjust Auto Exporter Approach to Constrain Exports to Specific Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ case of any other exception the code `-187` is returned with the value
 of `getMessage()` as returned by the exception itself.
 
 ### Auto Discovery With Annotations
+
 Spring can also be configured to auto-discover services and clients with annotations.
 
 To configure auto-discovery of annotated services first annotate the service interface:
@@ -196,14 +197,23 @@ interface MyService {
 }
 ```
 
-and use the following configuration to allow spring to find it:
+Next annotate the implementation of the service interface;
+
+```java
+@AutoJsonRpcServiceImpl
+class MyServiceImpl {
+... service methods' implementations ...
+}
+```
+
+and use the following configuration to allow spring to find the implementation that you would like to expose:
 
 ```xml
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-  <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter"/>
+  <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImplExporter"/>
 
   <bean class="com.mycompany.MyServiceImpl" />
 

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
@@ -27,16 +27,15 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
- * Auto exports {@link JsonRpcService} annotated beans as JSON-RPC services.
- * <p>
- * Minimizes the configuration necessary to export beans as JSON-RPC services to:
- *
- * <pre>
- * &lt;bean class=&quot;com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter&quot;/&gt;
- *
- * &lt;bean class="MyServiceBean"/&gt;
- * </pre>
+ * <p>This exporter class is deprecated because it exposes all beans from a spring context that has the
+ * {@link JsonRpcService} annotation.  If that context is also consuming JSON-RPC services from a remote
+ * system and has proxy clients instantiated in the same context then those proxy clients will also
+ * be (inadvertently) exposed by {@link AutoJsonRpcServiceExporter}.  To avoid this, switch over to use
+ * {@link AutoJsonRpcServiceImplExporter} which exposes specific implementations of the JSON-RPC services'
+ * interfaces rather than all beans that implement {@link JsonRpcService}.</p>
+ * @deprecated use {@link AutoJsonRpcServiceImplExporter} instead.
  */
+@Deprecated
 @SuppressWarnings("unused")
 public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImpl.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImpl.java
@@ -1,0 +1,30 @@
+package com.googlecode.jsonrpc4j.spring;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation goes on the <em>implementation</em> of the JSON-RPC service.  It defines any additional paths on
+ * which the JSON-RPC service should be exported.  This can be used with the {@link AutoJsonRpcServiceImplExporter}
+ * in order to automatically expose the JSON-RPC services in a spring based web application server.  Note that the
+ * implementation should still continue to carry the {@link com.googlecode.jsonrpc4j.JsonRpcServer} annotation;
+ * preferably on the service interface.
+ */
+
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface AutoJsonRpcServiceImpl {
+
+    /**
+     * This value may contain a list of <em>additional</em> paths that the JSON-RPC service will be exposed on.
+     * These are in addition to any which are defined on the {@link com.googlecode.jsonrpc4j.JsonRpcService}
+     * annotation preferably on the service interface.  This might be used, for example, where you still want
+     * to expose a service on legacy paths for older clients.
+     */
+
+    String[] additionalPaths() default {};
+
+}

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
@@ -1,0 +1,297 @@
+package com.googlecode.jsonrpc4j.spring;
+
+import static java.lang.String.format;
+import static org.springframework.util.ClassUtils.forName;
+import static org.springframework.util.ClassUtils.getAllInterfacesForClass;
+
+import com.googlecode.jsonrpc4j.*;
+import org.apache.logging.log4j.LogManager;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+
+import com.googlecode.jsonrpc4j.ErrorResolver;
+import com.googlecode.jsonrpc4j.InvocationListener;
+import com.googlecode.jsonrpc4j.JsonRpcService;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
+/**
+ * <p>
+ * This class can be instantiated in a spring context in order to simplify the configuration of JSON-RPC
+ * services afforded by beans in the same context.  The services to be configured are identified
+ * by the annotation {@link AutoJsonRpcServiceImpl} on the implementation of the service.  Such
+ * implementation beans must also have the {@link JsonRpcService} annotation associated with them; either
+ * on the implementation class itself or, preferably, on an interface that the implementation implements.
+ * </p>
+ *
+ * <p>The path for exposing the service is obtained from {@link JsonRpcService#value()}, but it is also
+ * possible to define additional paths on {@link AutoJsonRpcServiceImpl#additionalPaths()}.</p>
+ *
+ * <p>Below is an example of spring context XML snippet that illustrates typical usage;</p>
+ *
+ * <pre>
+ * &lt;bean class=&quot;com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImplExporter&quot;/&gt;
+ * &lt;bean class="MyServiceBean"/&gt;
+ * </pre>
+ *
+ * <p>Note that this class replaces {@link AutoJsonRpcServiceExporter}.  See that class' javadoc
+ * for details.</p>
+ */
+@SuppressWarnings("unused")
+public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor {
+
+	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+
+	private static final String PATH_PREFIX = "/";
+
+	public final static Pattern PATTERN_JSONRPC_PATH = Pattern.compile("^/?[A-Za-z0-9._~-]+(/[A-Za-z0-9._~-]+)*$");
+
+	private ObjectMapper objectMapper;
+	private ErrorResolver errorResolver = null;
+	private Boolean registerTraceInterceptor;
+	private boolean backwardsCompatible = true;
+	private boolean rethrowExceptions = false;
+	private boolean allowExtraParams = false;
+	private boolean allowLessParams = false;
+	private InvocationListener invocationListener = null;
+	private HttpStatusCodeProvider httpStatusCodeProvider = null;
+	private ConvertedParameterTransformer convertedParameterTransformer = null;
+
+	/**
+	 * Finds the beans to expose.
+	 * <p>
+	 * Searches parent factories as well.
+	 */
+	private static Map<String, String> findServiceBeanDefinitions(ConfigurableListableBeanFactory beanFactory) {
+		final Map<String, String> serviceBeanNames = new HashMap<>();
+
+		for (String beanName : beanFactory.getBeanDefinitionNames()) {
+			AutoJsonRpcServiceImpl autoJsonRpcServiceImplAnnotation = beanFactory.findAnnotationOnBean(beanName, AutoJsonRpcServiceImpl.class);
+			JsonRpcService jsonRpcServiceAnnotation = beanFactory.findAnnotationOnBean(beanName, JsonRpcService.class);
+
+			if (null != autoJsonRpcServiceImplAnnotation) {
+
+				if(null == jsonRpcServiceAnnotation) {
+					throw new IllegalStateException("on the bean [" + beanName + "], @" +
+							AutoJsonRpcServiceImpl.class.getSimpleName() + " was found, but not @" +
+							JsonRpcService.class.getSimpleName() + " -- both are required");
+				}
+
+				List<String> paths = new ArrayList<>();
+				Collections.addAll(paths, autoJsonRpcServiceImplAnnotation.additionalPaths());
+				paths.add(jsonRpcServiceAnnotation.value());
+
+				for(String path : paths) {
+					if(!PATTERN_JSONRPC_PATH.matcher(path).matches()) {
+						throw new RuntimeException("the path [" + path + "] for the bean [" + beanName + "] is not valid");
+					}
+
+					logger.info(String.format("exporting bean [%s] ---> [%s]", beanName, path));
+					if (isNotDuplicateService(serviceBeanNames, beanName, path))
+						serviceBeanNames.put(path, beanName);
+				};
+
+			}
+		}
+
+		collectFromParentBeans(beanFactory, serviceBeanNames);
+		return serviceBeanNames;
+	}
+
+	@SuppressWarnings("Convert2streamapi")
+	private static void collectFromParentBeans(ConfigurableListableBeanFactory beanFactory, Map<String, String> serviceBeanNames) {
+		BeanFactory parentBeanFactory = beanFactory.getParentBeanFactory();
+		if (parentBeanFactory != null && ConfigurableListableBeanFactory.class.isInstance(parentBeanFactory)) {
+			for (Entry<String, String> entry : findServiceBeanDefinitions((ConfigurableListableBeanFactory) parentBeanFactory).entrySet()) {
+				if (isNotDuplicateService(serviceBeanNames, entry.getKey(), entry.getValue())) serviceBeanNames.put(entry.getKey(), entry.getValue());
+			}
+		}
+	}
+
+	private static boolean isNotDuplicateService(Map<String, String> serviceBeanNames, String beanName, String pathValue) {
+		if (serviceBeanNames.containsKey(pathValue)) {
+			String otherBeanName = serviceBeanNames.get(pathValue);
+			logger.debug("Duplicate JSON-RPC path specification: found {} on both [{}] and [{}].", pathValue, beanName, otherBeanName);
+			return false;
+		}
+		return true;
+	}
+
+	private static boolean hasServiceAnnotation(JsonRpcService jsonRpcPath) {
+		return jsonRpcPath != null;
+	}
+
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		DefaultListableBeanFactory defaultListableBeanFactory = (DefaultListableBeanFactory) beanFactory;
+		Map<String, String> servicePathToBeanName = findServiceBeanDefinitions(defaultListableBeanFactory);
+		for (Entry<String, String> entry : servicePathToBeanName.entrySet()) {
+			registerServiceProxy(defaultListableBeanFactory, makeUrlPath(entry.getKey()), entry.getValue());
+		}
+	}
+
+	/**
+	 * To make the
+	 * {@link org.springframework.web.servlet.handler.BeanNameUrlHandlerMapping}
+	 * export a bean automatically, the name should start with a '/'.
+	 */
+	private String makeUrlPath(String servicePath) {
+		if (null==servicePath || 0==servicePath.length()) {
+			throw new IllegalArgumentException("the service path must be provided");
+		}
+
+		if ('/' == servicePath.charAt(0)) {
+			return servicePath;
+		}
+
+		return PATH_PREFIX.concat(servicePath);
+	}
+
+	/**
+	 * Registers the new beans with the bean factory.
+	 */
+	private void registerServiceProxy(DefaultListableBeanFactory defaultListableBeanFactory, String servicePath, String serviceBeanName) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(JsonServiceExporter.class).addPropertyReference("service", serviceBeanName);
+		BeanDefinition serviceBeanDefinition = findBeanDefinition(defaultListableBeanFactory, serviceBeanName);
+		for (Class<?> currentInterface : getBeanInterfaces(serviceBeanDefinition, defaultListableBeanFactory.getBeanClassLoader())) {
+			if (currentInterface.isAnnotationPresent(JsonRpcService.class)) {
+				String serviceInterface = currentInterface.getName();
+				logger.debug("Registering interface '{}' for JSON-RPC bean [{}].", serviceInterface, serviceBeanName);
+				builder.addPropertyValue("serviceInterface", serviceInterface);
+				break;
+			}
+		}
+		if (objectMapper != null) {
+			builder.addPropertyValue("objectMapper", objectMapper);
+		}
+
+		if (errorResolver != null) {
+			builder.addPropertyValue("errorResolver", errorResolver);
+		}
+
+		if (invocationListener != null) {
+			builder.addPropertyValue("invocationListener", invocationListener);
+		}
+
+		if (registerTraceInterceptor != null) {
+			builder.addPropertyValue("registerTraceInterceptor", registerTraceInterceptor);
+		}
+
+		if (httpStatusCodeProvider != null) {
+			builder.addPropertyValue("httpStatusCodeProvider", httpStatusCodeProvider);
+		}
+
+		if (convertedParameterTransformer != null) {
+			builder.addPropertyValue("convertedParameterTransformer", convertedParameterTransformer);
+		}
+
+		builder.addPropertyValue("backwardsCompatible", backwardsCompatible);
+		builder.addPropertyValue("rethrowExceptions", rethrowExceptions);
+		builder.addPropertyValue("allowExtraParams", allowExtraParams);
+		builder.addPropertyValue("allowLessParams", allowLessParams);
+
+		defaultListableBeanFactory.registerBeanDefinition(servicePath, builder.getBeanDefinition());
+	}
+
+	/**
+	 * Find a {@link BeanDefinition} in the {@link BeanFactory} or it's parents.
+	 */
+	private BeanDefinition findBeanDefinition(ConfigurableListableBeanFactory beanFactory, String serviceBeanName) {
+		if (beanFactory.containsLocalBean(serviceBeanName)) return beanFactory.getBeanDefinition(serviceBeanName);
+		BeanFactory parentBeanFactory = beanFactory.getParentBeanFactory();
+		if (parentBeanFactory != null && ConfigurableListableBeanFactory.class.isInstance(parentBeanFactory))
+			return findBeanDefinition((ConfigurableListableBeanFactory) parentBeanFactory, serviceBeanName);
+		throw new RuntimeException(format("Bean with name '%s' can no longer be found.", serviceBeanName));
+	}
+
+	private Class<?>[] getBeanInterfaces(BeanDefinition serviceBeanDefinition, ClassLoader beanClassLoader) {
+		String beanClassName = serviceBeanDefinition.getBeanClassName();
+		try {
+			Class<?> beanClass = forName(beanClassName, beanClassLoader);
+			return getAllInterfacesForClass(beanClass, beanClassLoader);
+		} catch (ClassNotFoundException | LinkageError e) {
+			throw new RuntimeException(format("Cannot find bean class '%s'.", beanClassName), e);
+		}
+	}
+
+	/**
+	 * @param objectMapper the objectMapper to set
+	 */
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	/**
+	 * @param errorResolver the errorResolver to set
+	 */
+	public void setErrorResolver(ErrorResolver errorResolver) {
+		this.errorResolver = errorResolver;
+	}
+
+	/**
+	 * @param backwardsCompatible the backwardsCompatible to set
+	 */
+	public void setBackwardsCompatible(boolean backwardsCompatible) {
+		this.backwardsCompatible = backwardsCompatible;
+	}
+
+	/**
+	 * @param rethrowExceptions the rethrowExceptions to set
+	 */
+	public void setRethrowExceptions(boolean rethrowExceptions) {
+		this.rethrowExceptions = rethrowExceptions;
+	}
+
+	/**
+	 * @param allowExtraParams the allowExtraParams to set
+	 */
+	public void setAllowExtraParams(boolean allowExtraParams) {
+		this.allowExtraParams = allowExtraParams;
+	}
+
+	/**
+	 * @param allowLessParams the allowLessParams to set
+	 */
+	public void setAllowLessParams(boolean allowLessParams) {
+		this.allowLessParams = allowLessParams;
+	}
+
+	/**
+	 * See {@link org.springframework.remoting.support.RemoteExporter#setRegisterTraceInterceptor(boolean)}
+	 * @param registerTraceInterceptor the registerTraceInterceptor value to set
+	 */
+	public void setRegisterTraceInterceptor(boolean registerTraceInterceptor) {
+		this.registerTraceInterceptor = registerTraceInterceptor;
+	}
+
+	/**
+	 * @param invocationListener the invocationListener to set
+	 */
+	public void setInvocationListener(InvocationListener invocationListener) {
+		this.invocationListener = invocationListener;
+	}
+
+	/**
+	 * @param httpStatusCodeProvider the HttpStatusCodeProvider to set
+	 */
+	public void setHttpStatusCodeProvider(HttpStatusCodeProvider httpStatusCodeProvider) {
+		this.httpStatusCodeProvider = httpStatusCodeProvider;
+	}
+
+	/**
+	 *
+	 * @param convertedParameterTransformer the convertedParameterTransformer to set
+	 */
+	public void setConvertedParameterTransformer(ConvertedParameterTransformer convertedParameterTransformer) {
+		this.convertedParameterTransformer = convertedParameterTransformer;
+	}
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathServerIntegrationTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathServerIntegrationTest.java
@@ -9,8 +9,14 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+/**
+ * @deprecated this test should be removed (replaced by {@link JsonRpcPathServerIntegrationTestB})
+ * once the {@link AutoJsonRpcServiceExporter} is dropped.
+ */
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:serverApplicationContext.xml")
+@Deprecated
 public class JsonRpcPathServerIntegrationTest {
 
   @Autowired

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathServerIntegrationTestB.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/JsonRpcPathServerIntegrationTestB.java
@@ -1,0 +1,75 @@
+package com.googlecode.jsonrpc4j.spring;
+
+import com.googlecode.jsonrpc4j.spring.serviceb.NoopTemperatureImpl;
+import com.googlecode.jsonrpc4j.spring.serviceb.Temperature;
+import com.googlecode.jsonrpc4j.spring.serviceb.TemperatureImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * <p>This test replaces {@link JsonRpcPathServerIntegrationTest} and uses the new class
+ * {@link AutoJsonRpcServiceImplExporter} which is designed to vend specific annotated
+ * implementations.</p>
+ */
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:serverApplicationContextB.xml")
+public class JsonRpcPathServerIntegrationTestB {
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	public void testExportedService() {
+		assertNotNull(applicationContext);
+
+		// check that the service was vended on both paths that were configured.
+
+		{
+			Object bean = applicationContext.getBean("/api/temperature");
+			assertSame(JsonServiceExporter.class, bean.getClass());
+		}
+
+		{
+			Object bean = applicationContext.getBean("/api-web/temperature");
+			assertSame(JsonServiceExporter.class, bean.getClass());
+		}
+
+		// check that the bean was only exported on the two paths provided.
+
+		{
+			String[] names = applicationContext.getBeanNamesForType(JsonServiceExporter.class);
+			Arrays.sort(names);
+			assertSame(2, names.length);
+			assertEquals("/api-web/temperature", names[0]);
+			assertEquals("/api/temperature", names[1]);
+		}
+
+		// check that the no-op was also successfully configured in the context.
+
+		{
+			Map<String,? extends Temperature> beans  = applicationContext.getBeansOfType(Temperature.class);
+			assertSame(2, beans.size());
+			Set<Class<? extends Temperature>> beanClasses = new HashSet<>();
+
+			for(Temperature temperature : beans.values()) {
+				beanClasses.add(temperature.getClass());
+			}
+
+			assertTrue(beanClasses.contains(NoopTemperatureImpl.class));
+			assertTrue(beanClasses.contains(TemperatureImpl.class));
+		}
+	}
+
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/serviceb/NoopTemperatureImpl.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/serviceb/NoopTemperatureImpl.java
@@ -1,0 +1,15 @@
+package com.googlecode.jsonrpc4j.spring.serviceb;
+
+/**
+ * <p>This implementation should not be picked up by the
+ * {@link com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImplExporter}
+ * bean because it does not have the necessary annotation.</p>
+ */
+
+public class NoopTemperatureImpl implements Temperature {
+
+	@Override
+	public Integer currentTemperature() {
+		return 0;
+	}
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/serviceb/Temperature.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/serviceb/Temperature.java
@@ -1,0 +1,13 @@
+package com.googlecode.jsonrpc4j.spring.serviceb;
+
+import com.googlecode.jsonrpc4j.JsonRpcService;
+
+@JsonRpcService(
+		"api/temperature" // note the absence of a leading slash
+)
+public interface Temperature {
+
+	@SuppressWarnings("unused")
+	Integer currentTemperature();
+
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/serviceb/TemperatureImpl.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/serviceb/TemperatureImpl.java
@@ -1,0 +1,21 @@
+package com.googlecode.jsonrpc4j.spring.serviceb;
+
+import com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImpl;
+
+/**
+ * <p>This implementation should be picked up by the
+ * {@link com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImplExporter}
+ * class.</p>
+ */
+
+@AutoJsonRpcServiceImpl(additionalPaths = {
+		"/api-web/temperature" // note the leading slash
+})
+public class TemperatureImpl implements Temperature {
+
+	@Override
+	public Integer currentTemperature() {
+		return 25;
+	}
+
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/serviceb/package.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/serviceb/package.java
@@ -1,0 +1,8 @@
+/**
+ * <p>This set of service classes is designed to test the
+ * {@link com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImplExporter} bean used to
+ * help with exposing JSON-RPC services.
+ * </p>
+ */
+
+package com.googlecode.jsonrpc4j.spring.serviceb;

--- a/src/test/resources/serverApplicationContextB.xml
+++ b/src/test/resources/serverApplicationContextB.xml
@@ -1,0 +1,9 @@
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <bean class="com.googlecode.jsonrpc4j.spring.serviceb.TemperatureImpl"/>
+    <bean class="com.googlecode.jsonrpc4j.spring.serviceb.NoopTemperatureImpl"/>
+    <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImplExporter"/>
+
+</beans>


### PR DESCRIPTION
The scenario in which this problem arises is where an application server vends as well as consumes JSON-RPC services.

```AutoJsonRpcServiceExporter``` vends *anything* with a ```JsonRpcService``` annotation.  In this problem scenario, proxies to other services are also effectively carrying a ```JsonRpcService``` annotation.  Those proxies that are intended for consuming other application servers' services are then also unintentionally vended/exposed/exported again as HTTP services and unintentionally act as HTTP reverse-proxies into the remote system.

This patch deprecates ```AutoJsonRpcServiceExporter``` and replaces it with ```AutoJsonRpcServiceImplExporter``` which leverages a new annotation ```AutoJsonRpcServiceImpl```.  ```AutoJsonRpcServiceImpl``` explicitly identifies the implementation of the interface that should be exposed.  This way, the proxy or proxies would not inadvertently be exposed.

The ```JsonRpcService``` annotation must still be present on the interface (or actually the implementation works too -- see #107) because the annotation is required for creating the consumer-side proxies and defining the path to access the service.

The ```JsonRpcService``` only allows for a service to be vended on a single path.  This limitation is overcome by allowing ```AutoJsonRpcServiceImpl``` to define additional paths.  The ```AutoJsonRpcServiceImplExporter``` will vend the service on all configured paths.  A client will use the single path from the ```JsonRpcService``` annotation.  A use-case for this is where a service's path is moved and the old path should be retained for some time to support older clients.

The old ```AutoJsonRpcServiceExporter``` is deprecated.

New tests employing ```AutoJsonRpcServiceImplExporter``` have been added with a "B" suffix.  The "B" suffix can be dropped once ```AutoJsonRpcServiceExporter``` is permanently dropped.

The ```README.md``` guidance for auto exporting has been updated to cover this new approach.