### PR TITLE
Extract the HTTP status code generating code into a provider.

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/DefaultHttpStatusCodeProvider.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/DefaultHttpStatusCodeProvider.java
@@ -1,16 +1,21 @@
 package com.googlecode.jsonrpc4j;
 
 import javax.servlet.http.HttpServletResponse;
-
 import java.util.Arrays;
 
-import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.*;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.BULK_ERROR;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.CUSTOM_SERVER_ERROR_LOWER;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.CUSTOM_SERVER_ERROR_UPPER;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.ERROR_NOT_HANDLED;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.INTERNAL_ERROR;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.INVALID_REQUEST;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.METHOD_NOT_FOUND;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.METHOD_PARAMS_INVALID;
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.PARSE_ERROR;
 
 /**
  * This default implementation of a {@link HttpStatusCodeProvider} follows the rules defined in the
  * <a href="http://www.jsonrpc.org/historical/json-rpc-over-http.html">JSON-RPC over HTTP</a> document.
- *
- *
  */
 public enum DefaultHttpStatusCodeProvider implements HttpStatusCodeProvider {
 	INSTANCE;

--- a/src/main/java/com/googlecode/jsonrpc4j/DefaultHttpStatusCodeProvider.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/DefaultHttpStatusCodeProvider.java
@@ -1,0 +1,39 @@
+package com.googlecode.jsonrpc4j;
+
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.Arrays;
+
+import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.*;
+
+/**
+ * This default implementation of a {@link HttpStatusCodeProvider} follows the rules defined in the
+ * <a href="http://www.jsonrpc.org/historical/json-rpc-over-http.html">JSON-RPC over HTTP</a> document.
+ *
+ *
+ */
+public enum DefaultHttpStatusCodeProvider implements HttpStatusCodeProvider {
+	INSTANCE;
+
+	@Override
+	public int getHttpStatusCode(int resultCode) {
+		if (resultCode == 0) return HttpServletResponse.SC_OK;
+
+		if (isErrorCode(resultCode)) {
+			return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+		} else if (resultCode == INVALID_REQUEST.code || resultCode == PARSE_ERROR.code) {
+			return HttpServletResponse.SC_BAD_REQUEST;
+		} else if (resultCode == METHOD_NOT_FOUND.code) {
+			return HttpServletResponse.SC_NOT_FOUND;
+		}
+
+		return HttpServletResponse.SC_OK;
+	}
+
+	private boolean isErrorCode(int result) {
+		for (ErrorResolver.JsonError error : Arrays.asList(INTERNAL_ERROR, METHOD_PARAMS_INVALID, ERROR_NOT_HANDLED, BULK_ERROR)) {
+			if (error.code == result) return true;
+		}
+		return CUSTOM_SERVER_ERROR_UPPER >= result && result >= CUSTOM_SERVER_ERROR_LOWER;
+	}
+}

--- a/src/main/java/com/googlecode/jsonrpc4j/HttpStatusCodeProvider.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/HttpStatusCodeProvider.java
@@ -1,0 +1,27 @@
+package com.googlecode.jsonrpc4j;
+
+/**
+ * <p>
+ * A status code provider maps an HTTP status code to a JSON-RPC result code (e.g. -32000 -&gt; 500).
+ * </p>
+ * <p>
+ * From version 2.0 on the JSON-RPC specification is not explicitly documenting the mapping of result/error codes, so
+ * this provider can be used to configure application specific HTTP status codes for a given JSON-RPC error code.
+ * </p>
+ * <p>
+ * The default implementation {@link DefaultHttpStatusCodeProvider} follows the rules defined in the
+ * <a href="http://www.jsonrpc.org/historical/json-rpc-over-http.html">JSON-RPC over HTTP</a> document.
+ * </p>
+ *
+ */
+public interface HttpStatusCodeProvider {
+
+	/**
+	 * Returns an HTTP status code for the given response and result code.
+	 *
+	 * @param resultCode the result code of the current JSON-RPC method call. This is used to look up the HTTP status
+	 *                   code.
+	 * @return the int representation of the HTTP status code that should be used by the JSON-RPC response.
+	 */
+	int getHttpStatusCode(int resultCode);
+}

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -74,6 +74,7 @@ public class JsonRpcBasicServer {
 	private final ObjectMapper mapper;
 	private final Class<?> remoteInterface;
 	private final Object handler;
+	protected HttpStatusCodeProvider httpStatusCodeProvider = null;
 	private boolean backwardsCompatible = true;
 	private boolean rethrowExceptions = false;
 	private boolean allowExtraParams = false;
@@ -749,6 +750,16 @@ public class JsonRpcBasicServer {
 
 	public void setInvocationListener(InvocationListener invocationListener) {
 		this.invocationListener = invocationListener;
+	}
+
+	/**
+	 * Sets the {@link HttpStatusCodeProvider} instance to use for HTTP error results.
+	 *
+	 * @param httpStatusCodeProvider the status code provider to use for translating JSON-RPC error codes into
+	 *                               HTTP status messages.
+     */
+	public void setHttpStatusCodeProvider(HttpStatusCodeProvider httpStatusCodeProvider) {
+		this.httpStatusCodeProvider = httpStatusCodeProvider;
 	}
 
 	private static class ErrorObjectWithJsonError {

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
@@ -1,5 +1,6 @@
 package com.googlecode.jsonrpc4j.spring;
 
+import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
@@ -31,6 +32,7 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 	private boolean allowExtraParams = false;
 	private boolean allowLessParams = false;
 	private InvocationListener invocationListener = null;
+	private HttpStatusCodeProvider httpStatusCodeProvider = null;
 
 	/**
 	 * {@inheritDoc}
@@ -58,6 +60,7 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 		jsonRpcServer.setAllowExtraParams(allowExtraParams);
 		jsonRpcServer.setAllowLessParams(allowLessParams);
 		jsonRpcServer.setInvocationListener(invocationListener);
+		jsonRpcServer.setHttpStatusCodeProvider(httpStatusCodeProvider);
 
 		exportService();
 	}
@@ -148,4 +151,10 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 		this.invocationListener = invocationListener;
 	}
 
+	/**
+	 * @param httpStatusCodeProvider the HttpStatusCodeProvider to set
+	 */
+	public void setHttpStatusCodeProvider(HttpStatusCodeProvider httpStatusCodeProvider) {
+		this.httpStatusCodeProvider = httpStatusCodeProvider;
+	}
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static org.springframework.util.ClassUtils.forName;
 import static org.springframework.util.ClassUtils.getAllInterfacesForClass;
 
+import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
 import org.apache.logging.log4j.LogManager;
 
 import org.springframework.beans.BeansException;
@@ -28,10 +29,10 @@ import java.util.Map.Entry;
  * Auto exports {@link JsonRpcService} annotated beans as JSON-RPC services.
  * <p>
  * Minimizes the configuration necessary to export beans as JSON-RPC services to:
- * 
+ *
  * <pre>
  * &lt;bean class=&quot;com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter&quot;/&gt;
- * 
+ *
  * &lt;bean class="MyServiceBean"/&gt;
  * </pre>
  */
@@ -50,6 +51,7 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 	private boolean allowExtraParams = false;
 	private boolean allowLessParams = false;
 	private InvocationListener invocationListener = null;
+	private HttpStatusCodeProvider httpStatusCodeProvider = null;
 
 	/**
 	 * Finds the beans to expose
@@ -141,6 +143,10 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 			builder.addPropertyValue("registerTraceInterceptor", registerTraceInterceptor);
 		}
 
+		if (httpStatusCodeProvider != null) {
+			builder.addPropertyValue("httpStatusCodeProvider", httpStatusCodeProvider);
+		}
+
 		builder.addPropertyValue("backwardsCompatible", backwardsCompatible);
 		builder.addPropertyValue("rethrowExceptions", rethrowExceptions);
 		builder.addPropertyValue("allowExtraParams", allowExtraParams);
@@ -225,5 +231,12 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 	 */
 	public void setInvocationListener(InvocationListener invocationListener) {
 		this.invocationListener = invocationListener;
+	}
+
+	/**
+	 * @param httpStatusCodeProvider the HttpStatusCodeProvider to set
+	 */
+	public void setHttpStatusCodeProvider(HttpStatusCodeProvider httpStatusCodeProvider) {
+		this.httpStatusCodeProvider = httpStatusCodeProvider;
 	}
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/server/DefaultHttpStatusCodeProviderTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/DefaultHttpStatusCodeProviderTest.java
@@ -1,0 +1,93 @@
+package com.googlecode.jsonrpc4j.server;
+
+import com.googlecode.jsonrpc4j.JsonRpcServer;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.MockType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.InputStream;
+
+import static com.googlecode.jsonrpc4j.util.Util.convertInputStreamToByteArray;
+import static com.googlecode.jsonrpc4j.util.Util.intParam1;
+import static com.googlecode.jsonrpc4j.util.Util.intParam2;
+import static com.googlecode.jsonrpc4j.util.Util.invalidJsonRpcRequestStream;
+import static com.googlecode.jsonrpc4j.util.Util.invalidJsonStream;
+import static com.googlecode.jsonrpc4j.util.Util.mapper;
+import static com.googlecode.jsonrpc4j.util.Util.messageWithListParams;
+import static com.googlecode.jsonrpc4j.util.Util.messageWithListParamsStream;
+import static com.googlecode.jsonrpc4j.util.Util.multiMessageOfStream;
+import static com.googlecode.jsonrpc4j.util.Util.param1;
+import static com.googlecode.jsonrpc4j.util.Util.param2;
+
+/**
+ * This class validates the mapping of JSON-RPC result codes to HTTP status codes.
+ */
+@RunWith(EasyMockRunner.class)
+public class DefaultHttpStatusCodeProviderTest {
+
+	@Mock(type = MockType.NICE)
+	private JsonRpcServerTest.ServiceInterface mockService;
+	private JsonRpcServer jsonRpcServer;
+
+	@Before
+	public void setUp() throws Exception {
+		jsonRpcServer = new JsonRpcServer(mapper, mockService, JsonRpcServerTest.ServiceInterface.class);
+	}
+
+	@Test
+	public void http400ForInvalidRequest() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(invalidJsonRpcRequestStream(), 400, jsonRpcServer);
+	}
+
+	@Test
+	public void http400ForParseError() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(invalidJsonStream(), 400, jsonRpcServer);
+	}
+
+	@Test
+	public void http200ForValidRequest() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(messageWithListParamsStream(1, "testMethod", param1), 200, jsonRpcServer);
+	}
+
+	@Test
+	public void http404ForNonExistingMethod() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(messageWithListParamsStream(1, "nonExistingMethod", param1), 404, jsonRpcServer);
+	}
+
+	@Test
+	public void http500ForInvalidMethodParameters() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(messageWithListParamsStream(1, "testMethod", param1, param2), 500, jsonRpcServer);
+	}
+
+	@Test
+	public void http500ForBulkErrors() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(
+				multiMessageOfStream(
+						messageWithListParams(1, "testMethod", param1, param2),
+						messageWithListParams(2, "overloadedMethod", intParam1, intParam2)
+				), 500, jsonRpcServer);
+	}
+
+	@Test
+	public void http500ForErrorNotHandled() throws Exception {
+		JsonRpcServer server = new JsonRpcServer(mapper, mockService, JsonRpcErrorsTest.ServiceInterfaceWithoutAnnotation.class);
+		assertHttpStatusCodeForJsonRpcRequest(messageWithListParamsStream(1, "testMethod"), 500, server);
+	}
+
+	public static void assertHttpStatusCodeForJsonRpcRequest(InputStream message, int expectedCode, JsonRpcServer server) throws Exception {
+		MockHttpServletRequest req = new MockHttpServletRequest();
+		MockHttpServletResponse res = new MockHttpServletResponse();
+		req.setMethod(HttpMethod.POST.name());
+		req.setContent(convertInputStreamToByteArray(message));
+		server.handle(req, res);
+		Assert.assertEquals(expectedCode, res.getStatus());
+	}
+
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/server/HttpStatusCodeProviderTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/HttpStatusCodeProviderTest.java
@@ -1,0 +1,103 @@
+package com.googlecode.jsonrpc4j.server;
+
+import com.googlecode.jsonrpc4j.HttpStatusCodeProvider;
+import com.googlecode.jsonrpc4j.JsonRpcServer;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.MockType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.googlecode.jsonrpc4j.server.DefaultHttpStatusCodeProviderTest.assertHttpStatusCodeForJsonRpcRequest;
+import static com.googlecode.jsonrpc4j.util.Util.intParam1;
+import static com.googlecode.jsonrpc4j.util.Util.intParam2;
+import static com.googlecode.jsonrpc4j.util.Util.invalidJsonRpcRequestStream;
+import static com.googlecode.jsonrpc4j.util.Util.invalidJsonStream;
+import static com.googlecode.jsonrpc4j.util.Util.mapper;
+import static com.googlecode.jsonrpc4j.util.Util.messageWithListParams;
+import static com.googlecode.jsonrpc4j.util.Util.messageWithListParamsStream;
+import static com.googlecode.jsonrpc4j.util.Util.multiMessageOfStream;
+import static com.googlecode.jsonrpc4j.util.Util.param1;
+import static com.googlecode.jsonrpc4j.util.Util.param2;
+
+/**
+ * These tests validate the functionality of a custom HttpStatusCodeProvider implementation.
+ */
+@RunWith(EasyMockRunner.class)
+public class HttpStatusCodeProviderTest {
+
+	@Mock(type = MockType.NICE)
+	private JsonRpcServerTest.ServiceInterface mockService;
+	private JsonRpcServer jsonRpcServer;
+	private HttpStatusCodeProvider httpStatusCodeProvider;
+
+	@Before
+	public void setUp() throws Exception {
+		jsonRpcServer = new JsonRpcServer(mapper, mockService, JsonRpcServerTest.ServiceInterface.class);
+		httpStatusCodeProvider = new HttpStatusCodeProvider() {
+			@Override
+			public int getHttpStatusCode(int resultCode) {
+				switch (resultCode) {
+					case -32600:
+						return 1001;
+					case -32700:
+						return 1002;
+					case -32601:
+						return 1003;
+					case -32602:
+						return 1004;
+					case -32002:
+						return 1005;
+					case -32001:
+						return 1006;
+					default:
+						return 1000;
+				}
+			}
+		};
+		jsonRpcServer.setHttpStatusCodeProvider(httpStatusCodeProvider);
+	}
+
+	@Test
+	public void http1001ForInvalidRequest() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(invalidJsonRpcRequestStream(), 1001, jsonRpcServer);
+	}
+
+	@Test
+	public void http1002ForParseError() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(invalidJsonStream(), 1002, jsonRpcServer);
+	}
+
+	@Test
+	public void http1000ForValidRequest() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(messageWithListParamsStream(1, "testMethod", param1), 1000, jsonRpcServer);
+	}
+
+	@Test
+	public void http1003ForNonExistingMethod() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(messageWithListParamsStream(1, "nonExistingMethod", param1), 1003, jsonRpcServer);
+	}
+
+	@Test
+	public void http1004ForInvalidMethodParameters() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(messageWithListParamsStream(1, "testMethod", param1, param2), 1004, jsonRpcServer);
+	}
+
+	@Test
+	public void http1005ForBulkErrors() throws Exception {
+		assertHttpStatusCodeForJsonRpcRequest(
+				multiMessageOfStream(
+						messageWithListParams(1, "testMethod", param1, param2),
+						messageWithListParams(2, "overloadedMethod", intParam1, intParam2)
+				), 1005, jsonRpcServer);
+	}
+
+	@Test
+	public void http1006ForErrorNotHandled() throws Exception {
+		JsonRpcServer server = new JsonRpcServer(mapper, mockService, JsonRpcErrorsTest.ServiceInterfaceWithoutAnnotation.class);
+		server.setHttpStatusCodeProvider(httpStatusCodeProvider);
+		assertHttpStatusCodeForJsonRpcRequest(messageWithListParamsStream(1, "testMethod"), 1006, server);
+	}
+
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/util/Util.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/Util.java
@@ -27,12 +27,17 @@ public class Util {
 	public static final ObjectMapper mapper = new ObjectMapper();
 	@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 	public static final String DEFAULT_LOCAL_HOSTNAME = "127.0.0.1";
+	private static final String invalidJsonRpcRequest = "{\"method\": \"subtract\", \"params\": [], \"id\": 1}";
 	private static final String invalidJson = "{\"jsonrpc\": \"2.0,\n" +
 			" \"method\": \"testMethod\",\n" +
 			" \"params\": {},\n" +
 			" \"id\": \n" +
 			" }\n" +
 			" ";
+
+	public static InputStream invalidJsonRpcRequestStream() {
+		return new ByteArrayInputStream(invalidJsonRpcRequest.getBytes(StandardCharsets.UTF_8));
+	}
 
 	public static InputStream invalidJsonStream() {
 		return new ByteArrayInputStream(invalidJson.getBytes(StandardCharsets.UTF_8));
@@ -93,5 +98,26 @@ public class Util {
 			if (n.get(JsonRpcBasicServer.ID).asInt() == id) { return n; }
 		}
 		throw new IllegalStateException("could not find in " + node + " id " + id);
+	}
+
+	/**
+	 * Simple input stream to byte array converter.
+	 *
+	 * @param inputStream the input stream that will be converted.
+	 * @return the content of the input stream in form of a byte array.
+	 * @throws IOException thrown if there was an IO error while converting data.
+	 */
+	public static byte[] convertInputStreamToByteArray(InputStream inputStream) throws IOException {
+
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		int read;
+		byte[] data = new byte[512];
+		while ((read = inputStream.read(data, 0, data.length)) != -1) {
+			buffer.write(data, 0, read);
+		}
+
+		buffer.flush();
+		return buffer.toByteArray();
 	}
 }


### PR DESCRIPTION
My current JSON-RPC clients assume that JSON-RPC returns an HTTP status code of 200 unless there was an HTTP related error. This was the default behaviour before JSON-RPC4j 1.2.

#72 and #73 implemented a proposal for JSON-RPC 1.2 (http://www.jsonrpc.org/historical/json-rpc-over-http.html). Now JSON-RPC4j returns a different HTTP status code if the response contains an JSON-RPC error code.

The JSON-RPC 2.0 spec does not contain information about HTTP status codes. Proposals for JSON-RPC over HTTP exist for different protocol versions, but they are not part of the specifications. For JSON-RPC 2.0 for example there is another proposal available here (http://www.simple-is-better.org/json-rpc/extension_transport.html).

This change implements an interface for the status code generating code and a default implementation reflecting the existing behaviour from #73. In case one wants to map the JSON-RPC result codes to different HTTP status codes this interface could be implemented to replace the default behaviour.