### PR TITLE
#119 Allow extension of JsonRpcServer

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -200,7 +200,7 @@ public class JsonRpcBasicServer {
 	 * @param serviceName the optional name of a service
 	 * @return the class
 	 */
-	Class<?>[] getHandlerInterfaces(final String serviceName) {
+	protected Class<?>[] getHandlerInterfaces(final String serviceName) {
 		if (remoteInterface != null) {
 			return new Class<?>[] { remoteInterface };
 		} else if (Proxy.isProxyClass(handler.getClass())) {
@@ -218,7 +218,7 @@ public class JsonRpcBasicServer {
 	 * @return the error code, or {@code 0} if none
 	 * @throws IOException on error
 	 */
-	private JsonError handleJsonNodeRequest(final JsonNode node, final OutputStream output) throws IOException {
+	protected JsonError handleJsonNodeRequest(final JsonNode node, final OutputStream output) throws IOException {
 		if (node.isArray()) return handleArray(ArrayNode.class.cast(node), output);
 		if (node.isObject()) return handleObject(ObjectNode.class.cast(node), output);
 		return this.writeAndFlushValueError(output, this.createResponseError(VERSION, NULL, JsonError.INVALID_REQUEST));
@@ -352,7 +352,7 @@ public class JsonRpcBasicServer {
 	 * @param methodName the JsonNode for the method
 	 * @return the name of the service, or <code>null</code>
 	 */
-	String getServiceName(final String methodName) {
+	protected String getServiceName(final String methodName) {
 		return null;
 	}
 
@@ -362,7 +362,7 @@ public class JsonRpcBasicServer {
 	 * @param methodName the JsonNode for the method
 	 * @return the name of the method that should be invoked
 	 */
-	String getMethodName(final String methodName) {
+	protected String getMethodName(final String methodName) {
 		return methodName;
 	}
 
@@ -373,7 +373,7 @@ public class JsonRpcBasicServer {
 	 * @param serviceName an optional service name
 	 * @return the handler to invoke the RPC call against
 	 */
-	Object getHandler(String serviceName) {
+	protected Object getHandler(String serviceName) {
 		return handler;
 	}
 

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcMultiServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcMultiServer.java
@@ -136,7 +136,7 @@ public class JsonRpcMultiServer extends JsonRpcServer {
 	 * @return the handler to invoke the RPC call against
 	 */
 	@Override
-	Object getHandler(String serviceName) {
+	protected Object getHandler(String serviceName) {
 		Object handler = handlerMap.get(serviceName);
 		if (handler == null) {
 			logger.error("Service '{}' is not registered in this multi-server", serviceName);

--- a/src/main/java/com/googlecode/jsonrpc4j/ReflectionUtil.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ReflectionUtil.java
@@ -125,7 +125,7 @@ public abstract class ReflectionUtil {
 	 * @param type the type of annotation
 	 * @return the annotation or null
 	 */
-	static <T extends Annotation> T getAnnotation(Method method, Class<T> type) {
+	public static <T extends Annotation> T getAnnotation(Method method, Class<T> type) {
 		for (Annotation a : getAnnotations(method)) {
 			if (type.isInstance(a)) { return type.cast(a); }
 		}


### PR DESCRIPTION
Those methods were protected or public pre-1.3.0, and allowed extensibility.
They remained package-visible, which allowed JsonRpcMultiServer to continue
extend JsonRpcServer. Make them protected again to allow other extensions out
of the jsonrpc4j package.

Also make a ReflectionUtil method public again, which is useful to implement
ErrorResolver for example.