### PR TITLE
#121 Use slf4j instead of log4j2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,11 @@ dependencies {
         springVersion = '4.2.5.RELEASE'
         springBotVersion = '1.3.3.RELEASE'
         jettyVersion = '9.3.8.RC0'
+        slf4jVersion = '1.7.9'
     }
 
     compile 'net.iharder:base64:2.3.9'
-    compile 'org.apache.logging.log4j:log4j-core:2.5'
+    compile "org.slf4j:slf4j-api:${slf4jVersion}"
     provided 'javax.portlet:portlet-api:2.0'
     provided 'javax.servlet:javax.servlet-api:3.1.0'
 
@@ -63,14 +64,18 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.easymock:easymock:3.4'
-    testCompile "org.springframework.boot:spring-boot-starter-web:${springBotVersion}"
-    testCompile("org.springframework.boot:spring-boot-starter-test:${springBotVersion}")
+    testCompile("org.springframework.boot:spring-boot-starter-web:${springBotVersion}") {
+        exclude module: 'logback-classic'
+    }
+    testCompile "org.springframework.boot:spring-boot-starter-test:${springBotVersion}"
     testCompile("org.eclipse.jetty:jetty-server:${jettyVersion}") {
         exclude module: 'javax.servlet'
     }
     testCompile("org.eclipse.jetty:jetty-servlet:${jettyVersion}") {
         exclude module: 'org.eclipse.jetty.orbit'
     }
+    testRuntime 'org.apache.logging.log4j:log4j-slf4j-impl:2.5'
+    testRuntime 'org.apache.logging.log4j:log4j-core:2.5'
 
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/DefaultExceptionResolver.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/DefaultExceptionResolver.java
@@ -3,7 +3,8 @@ package com.googlecode.jsonrpc4j;
 import static com.googlecode.jsonrpc4j.Util.hasNonNullObjectData;
 import static com.googlecode.jsonrpc4j.Util.hasNonNullTextualData;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -17,7 +18,7 @@ import java.lang.reflect.InvocationTargetException;
 @SuppressWarnings("WeakerAccess")
 public enum DefaultExceptionResolver implements ExceptionResolver {
 	INSTANCE;
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(DefaultExceptionResolver.class);
 
 	/**
 	 * {@inheritDoc}

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -5,7 +5,8 @@ import static com.googlecode.jsonrpc4j.ReflectionUtil.findCandidateMethods;
 import static com.googlecode.jsonrpc4j.ReflectionUtil.getParameterTypes;
 import static com.googlecode.jsonrpc4j.Util.hasNonNullData;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
 
@@ -67,7 +68,7 @@ public class JsonRpcBasicServer {
 	public static final String WEB_PARAM_ANNOTATION_CLASS_LOADER = "javax.jws.WebParam";
 	public static final String NAME = "name";
 	public static final String NULL = "null";
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(JsonRpcBasicServer.class);
 	private static final ErrorResolver DEFAULT_ERROR_RESOLVER = new MultipleErrorResolver(AnnotationsErrorResolver.INSTANCE, DefaultErrorResolver.INSTANCE);
 	private static Class<? extends Annotation> WEB_PARAM_ANNOTATION_CLASS;
 	private static Method WEB_PARAM_NAME_METHOD;
@@ -144,7 +145,7 @@ public class JsonRpcBasicServer {
 			WEB_PARAM_ANNOTATION_CLASS = classLoader.loadClass(WEB_PARAM_ANNOTATION_CLASS_LOADER).asSubclass(Annotation.class);
 			WEB_PARAM_NAME_METHOD = WEB_PARAM_ANNOTATION_CLASS.getMethod(NAME);
 		} catch (ClassNotFoundException | NoSuchMethodException e) {
-			logger.error(e);
+			logger.error("Could not find {}.{}", WEB_PARAM_ANNOTATION_CLASS_LOADER, NAME, e);
 		}
 	}
 

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -9,7 +9,8 @@ import static com.googlecode.jsonrpc4j.JsonRpcBasicServer.RESULT;
 import static com.googlecode.jsonrpc4j.JsonRpcBasicServer.VERSION;
 import static com.googlecode.jsonrpc4j.Util.hasNonNullData;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JavaType;
@@ -33,7 +34,7 @@ import java.util.Random;
 @SuppressWarnings({ "WeakerAccess", "unused" })
 public class JsonRpcClient {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(JsonRpcClient.class);
 
 	private final ObjectMapper mapper;
 	private final Random random;

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpAsyncClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpAsyncClient.java
@@ -39,7 +39,8 @@ import org.apache.http.protocol.RequestContent;
 import org.apache.http.protocol.RequestExpectContinue;
 import org.apache.http.protocol.RequestTargetHost;
 import org.apache.http.protocol.RequestUserAgent;
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JavaType;
@@ -96,7 +97,7 @@ import javax.net.ssl.SSLContext;
 @SuppressWarnings({ "WeakerAccess", "unused" })
 public class JsonRpcHttpAsyncClient {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(JsonRpcHttpAsyncClient.class);
 
 	private static final AtomicBoolean initialized = new AtomicBoolean();
 	private static final AtomicLong nextId = new AtomicLong();

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcMultiServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcMultiServer.java
@@ -1,6 +1,7 @@
 package com.googlecode.jsonrpc4j;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -40,7 +41,7 @@ import java.util.Map;
 public class JsonRpcMultiServer extends JsonRpcServer {
 
 	public static final char DEFAULT_SEPARATOR = '.';
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(JsonRpcMultiServer.class);
 
 	private final Map<String, Object> handlerMap;
 	private final Map<String, Class<?>> interfaceMap;

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -1,6 +1,7 @@
 package com.googlecode.jsonrpc4j;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -20,7 +21,7 @@ import javax.portlet.ResourceResponse;
  */
 @SuppressWarnings("unused")
 public class JsonRpcServer extends JsonRpcBasicServer {
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(JsonRpcServer.class);
 
 	/**
 	 * Creates the server with the given {@link ObjectMapper} delegating

--- a/src/main/java/com/googlecode/jsonrpc4j/ProxyUtil.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ProxyUtil.java
@@ -1,6 +1,7 @@
 package com.googlecode.jsonrpc4j;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.googlecode.jsonrpc4j.spring.rest.JsonRpcRestClient;
 
@@ -23,7 +24,7 @@ import java.util.Set;
 @SuppressWarnings({ "unused", "WeakerAccess" })
 public abstract class ProxyUtil {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(ProxyUtil.class);
 
 	/**
 	 * Creates a composite service using all of the given

--- a/src/main/java/com/googlecode/jsonrpc4j/StreamServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/StreamServer.java
@@ -1,6 +1,7 @@
 package com.googlecode.jsonrpc4j;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedInputStream;
 import java.io.Closeable;
@@ -29,7 +30,7 @@ import javax.net.ssl.SSLException;
 @SuppressWarnings({ "unused", "WeakerAccess" })
 public class StreamServer {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(StreamServer.class);
 
 	private static final long SERVER_SOCKET_SO_TIMEOUT = 5000;
 
@@ -128,7 +129,7 @@ public class StreamServer {
 		try {
 			serverSocket.close();
 		} catch (IOException e) {
-			logger.debug(e);
+			logger.debug("Failed to close socket", e);
 		}
 	}
 

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractCompositeJsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractCompositeJsonServiceExporter.java
@@ -1,7 +1,7 @@
 package com.googlecode.jsonrpc4j.spring;
 
-import org.apache.logging.log4j.LogManager;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @SuppressWarnings("unused")
 abstract class AbstractCompositeJsonServiceExporter implements InitializingBean, ApplicationContextAware {
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(AbstractCompositeJsonServiceExporter.class);
 
 	private ObjectMapper objectMapper;
 	private ApplicationContext applicationContext;
@@ -50,7 +50,7 @@ abstract class AbstractCompositeJsonServiceExporter implements InitializingBean,
 			try {
 				objectMapper = BeanFactoryUtils.beanOfTypeIncludingAncestors(applicationContext, ObjectMapper.class);
 			} catch (Exception e) {
-				logger.error(e);
+				logger.error("Could not load ObjectMapper from ApplicationContext", e);
 			}
 		}
 		if (objectMapper == null) {

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcClientProxyCreator.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcClientProxyCreator.java
@@ -4,8 +4,8 @@ import static java.lang.String.format;
 import static org.springframework.util.ClassUtils.convertClassNameToResourcePath;
 import static org.springframework.util.ResourceUtils.CLASSPATH_URL_PREFIX;
 
-import org.apache.logging.log4j.LogManager;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -33,7 +33,7 @@ import java.net.URL;
 @SuppressWarnings("unused")
 public class AutoJsonRpcClientProxyCreator implements BeanFactoryPostProcessor, ApplicationContextAware {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(AutoJsonRpcClientProxyCreator.class);
 	private ApplicationContext applicationContext;
 	private String scanPackage;
 	private URL baseUrl;

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
@@ -4,8 +4,8 @@ import static java.lang.String.format;
 import static org.springframework.util.ClassUtils.forName;
 import static org.springframework.util.ClassUtils.getAllInterfacesForClass;
 
-import org.apache.logging.log4j.LogManager;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -39,7 +39,7 @@ import java.util.Map.Entry;
 @SuppressWarnings("unused")
 public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(AutoJsonRpcServiceExporter.class);
 
 	private static final String PATH_PREFIX = "/";
 

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
@@ -4,8 +4,8 @@ import static java.lang.String.format;
 import static org.springframework.util.ClassUtils.forName;
 import static org.springframework.util.ClassUtils.getAllInterfacesForClass;
 
-import org.apache.logging.log4j.LogManager;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -55,7 +55,7 @@ import java.util.regex.Pattern;
 @SuppressWarnings("unused")
 public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(AutoJsonRpcServiceImplExporter.class);
 
 	private static final String PATH_PREFIX = "/";
 

--- a/src/test/java/com/googlecode/jsonrpc4j/integration/StreamServerTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/integration/StreamServerTest.java
@@ -4,8 +4,8 @@ import static com.googlecode.jsonrpc4j.util.Util.DEFAULT_LOCAL_HOSTNAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.apache.logging.log4j.LogManager;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ import javax.net.ServerSocketFactory;
 
 public class StreamServerTest {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(StreamServerTest.class);
 	private ServerSocket serverSocket;
 	private JsonRpcBasicServer jsonRpcServer;
 	private JsonRpcClient jsonRpcClient;

--- a/src/test/java/com/googlecode/jsonrpc4j/util/FakeServiceInterfaceImpl.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/FakeServiceInterfaceImpl.java
@@ -1,13 +1,14 @@
 package com.googlecode.jsonrpc4j.util;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 
 @SuppressWarnings("WeakerAccess")
 public class FakeServiceInterfaceImpl implements FakeServiceInterface {
 
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(FakeServiceInterfaceImpl.class);
 
 	@Override
 	public void doSomething() {

--- a/src/test/java/com/googlecode/jsonrpc4j/util/JettyServer.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/JettyServer.java
@@ -24,11 +24,11 @@ public class JettyServer implements AutoCloseable {
 	public static final String SERVLET = "someSunnyServlet";
 	private static final String PROTOCOL = "http";
 
-	private final Class service;
+	private final Class<?> service;
 	private Server jetty;
 	private int port;
 
-	JettyServer(Class service) {
+	JettyServer(Class<?> service) {
 		this.service = service;
 	}
 

--- a/src/test/java/com/googlecode/jsonrpc4j/util/LocalThreadServer.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/LocalThreadServer.java
@@ -1,6 +1,7 @@
 package com.googlecode.jsonrpc4j.util;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.googlecode.jsonrpc4j.JsonRpcClient;
 import com.googlecode.jsonrpc4j.JsonRpcServer;
@@ -17,7 +18,7 @@ import java.io.PipedOutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LocalThreadServer<T> extends Thread implements AutoCloseable {
-	private static final org.apache.logging.log4j.Logger logger = LogManager.getLogger();
+	private static final Logger logger = LoggerFactory.getLogger(LocalThreadServer.class);
 
 	private final InputStream serverInput = new PipedInputStream();
 	private final OutputStream serverOutput = new PipedOutputStream();

--- a/src/test/java/com/googlecode/jsonrpc4j/util/Util.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/Util.java
@@ -61,6 +61,7 @@ public class Util {
 		return makeJsonRpcRequestObject(id, methodName, params);
 	}
 
+	@SuppressWarnings("serial")
 	private static HashMap<String, Object> makeJsonRpcRequestObject(final Object id, final String methodName, final Object params) {
 		return new HashMap<String, Object>() {
 			{


### PR DESCRIPTION
Pre-13 versions used java.util.logging, which can easily be redirect using jul-to-slf4j, and then any slf4j implementation. See [1]

There is no such bridge for log4j 2.x.

I propose to use slf4j API in jsonrpc4j, as this is the de-facto standard. Clients of jsonrpc4j can then plug any logging framework they prefer.

[1] http://www.slf4j.org/manual.html