### PR TITLE
JsonRpcClient#readResponse public

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -496,7 +496,7 @@ public class JsonRpcClient {
 	 * @return the object returned by the JSON-RPC response
 	 * @throws Throwable on error
 	 */
-	Object readResponse(Type returnType, InputStream input) throws Throwable {
+	public Object readResponse(Type returnType, InputStream input) throws Throwable {
 		return readResponse(returnType, input, null);
 	}
 


### PR DESCRIPTION
Makes JsonRpcClient#readResponse public as it was in the 1.2.0 in order to use readResponse in interceptors the same way as JsonProxyFactoryBean do it with the invoke method.