### PR TITLE
Public constructor for JsonRpcHttpAsyncClient

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcCallback.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcCallback.java
@@ -9,7 +9,7 @@ package com.googlecode.jsonrpc4j;
  *
  * @param <T> the return type of the JSON-RPC call
  */
-interface JsonRpcCallback<T> {
+public interface JsonRpcCallback<T> {
 
 	/**
 	 * Called if the remote invocation was successful.

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpAsyncClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpAsyncClient.java
@@ -127,7 +127,7 @@ public class JsonRpcHttpAsyncClient {
 	 * {@code serviceUrl}. The headers provided in the {@code headers} map are added to every request
 	 * made to the {@code serviceUrl}.
 	 *
-	 * @param mapper the {@link ObjectMapper} to use for json<->java conversion
+	 * @param mapper the {@link ObjectMapper} to use for json&lt;-&gt;java conversion
 	 * @param serviceUrl the service end-point URL
 	 * @param headers the headers
 	 */

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpAsyncClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpAsyncClient.java
@@ -118,7 +118,7 @@ public class JsonRpcHttpAsyncClient {
 	 * 
 	 * @param serviceUrl the service end-point URL
 	 */
-	private JsonRpcHttpAsyncClient(URL serviceUrl) {
+	public JsonRpcHttpAsyncClient(URL serviceUrl) {
 		this(new ObjectMapper(), serviceUrl, new HashMap<String, String>());
 	}
 
@@ -131,7 +131,7 @@ public class JsonRpcHttpAsyncClient {
 	 * @param serviceUrl the service end-point URL
 	 * @param headers the headers
 	 */
-	private JsonRpcHttpAsyncClient(ObjectMapper mapper, URL serviceUrl, Map<String, String> headers) {
+	public JsonRpcHttpAsyncClient(ObjectMapper mapper, URL serviceUrl, Map<String, String> headers) {
 		this.mapper = mapper;
 		this.serviceUrl = serviceUrl;
 		this.headers.putAll(headers);
@@ -145,7 +145,7 @@ public class JsonRpcHttpAsyncClient {
 	 * @param serviceUrl the service end-point URL
 	 * @param headers the headers
 	 */
-	private JsonRpcHttpAsyncClient(URL serviceUrl, Map<String, String> headers) {
+	public JsonRpcHttpAsyncClient(URL serviceUrl, Map<String, String> headers) {
 		this(new ObjectMapper(), serviceUrl, headers);
 	}
 


### PR DESCRIPTION
Is there a reason why the JsonRpcHttpAsyncClient constructors are private? I couldn't find any references using these constructors inside the class (like a factory method or singleton instance), and they were not usable outside the class.

In thus commit, I have changed the visibility of the constructors to public, and also changed the scope of the JsonRpcCallback interface to public.

If there was no specific reason to effectively disable this class (by making the constructor private) please consider changing the visibility to public, so the library may be used as a jsonrpc async client as well.

(As a sidenote, the javadoc in JsonRpcHttpAsyncClient contained "<->" and gradle complained about it not being valid html, so I've also fixed this up.)