### PR TITLE
Only call servlet's getOutputStream right before we need to use it.

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -79,8 +79,8 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 	public void handle(ResourceRequest request, ResourceResponse response) throws IOException {
 		logger.debug("Handing ResourceRequest {}", request.getMethod());
 		response.setContentType(JSONRPC_CONTENT_TYPE);
-		OutputStream output = response.getPortletOutputStream();
 		InputStream input = getRequestStream(request);
+		OutputStream output = response.getPortletOutputStream();
 		handleRequest(input, output);
 		// fix to not flush within handleRequest() but outside so http status code can be set
 		output.flush();


### PR DESCRIPTION
Inside `JsonRpcBasicServer`, we call servlet's `getOutputStream` before we construct a internal `InputStream`. The problem is if anything happens during the construction time of `InputStream`, the downstream handlers cannot use the output stream any more. We should postpone the time we call `getOutputStream` after we finish constructing the input stream.