### PR TITLE
Use headers from client in ProxyUtil.createClientProxy

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/ProxyUtil.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ProxyUtil.java
@@ -167,7 +167,7 @@ public abstract class ProxyUtil {
 	 * @return the proxied interface
 	 */
 	public static <T> T createClientProxy(ClassLoader classLoader, Class<T> proxyInterface, final IJsonRpcClient client) {
-		return createClientProxy(classLoader, proxyInterface, client, new HashMap<String, String>());
+		return createClientProxy(classLoader, proxyInterface, client, client.getHeaders());
 	}
 
 	/**


### PR DESCRIPTION
Currently, ProxyUtil.createClientProxy always passed in a new, empty map for the additional request headers. This behavior is incorrect (or at least surprising) - it should take the extra header configuration from the provided client and use that.