### PR TITLE
Respect @JsonRpcMethod as a client

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/ProxyUtil.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ProxyUtil.java
@@ -151,7 +151,12 @@ public abstract class ProxyUtil {
 	}
 
 	private static String getMethodName(Method method) {
-		return method.getName();
+		final JsonRpcMethod jsonRpcMethod = ReflectionUtil.getAnnotation(method, JsonRpcMethod.class);
+		if(jsonRpcMethod == null){
+			return method.getName();
+		}else{
+			return jsonRpcMethod.value();
+		}
 	}
 
 	public static <T> T createClientProxy(Class<T> clazz, JsonRpcRestClient client) {


### PR DESCRIPTION
When making RPC calls using generated proxies, use the JsonRpcMethod annotation''s value (if present) to determine what to use as the RPC method name.