### PR TITLE
A return type of Void is not valid

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -256,7 +256,7 @@ public class JsonRpcClient {
 	}
 
 	private boolean isReturnTypeInvalid(Type returnType) {
-		if (returnType == null) {
+		if (returnType == null || returnType == Void.class) {
 			logger.warn("Server returned result but returnType is null");
 			return true;
 		}


### PR DESCRIPTION
When invoking methods with a return type of Void, consider Void to be not a valid return type allowing for there to be RPC methods that don't return anything (or have results that are ignored).