### PR TITLE
Support avoiding logging for invocation errors

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
@@ -32,6 +32,7 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 	private boolean rethrowExceptions = false;
 	private boolean allowExtraParams = false;
 	private boolean allowLessParams = false;
+	private boolean shouldLogInvocationErrors = true;
 	private InvocationListener invocationListener = null;
 	private HttpStatusCodeProvider httpStatusCodeProvider = null;
 	private ConvertedParameterTransformer convertedParameterTransformer = null;
@@ -71,6 +72,7 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 		jsonRpcServer.setInvocationListener(invocationListener);
 		jsonRpcServer.setHttpStatusCodeProvider(httpStatusCodeProvider);
 		jsonRpcServer.setConvertedParameterTransformer(convertedParameterTransformer);
+		jsonRpcServer.setShouldLogInvocationErrors(shouldLogInvocationErrors);
 
 		exportService();
 	}
@@ -174,5 +176,9 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 	 */
 	public void setConvertedParameterTransformer(ConvertedParameterTransformer convertedParameterTransformer) {
 		this.convertedParameterTransformer = convertedParameterTransformer;
+	}
+
+	public void setShouldLogInvocationErrors(boolean shouldLogInvocationErrors) {
+		this.shouldLogInvocationErrors = shouldLogInvocationErrors;
 	}
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
@@ -68,6 +68,7 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 	private boolean rethrowExceptions = false;
 	private boolean allowExtraParams = false;
 	private boolean allowLessParams = false;
+	private boolean shouldLogInvocationErrors = true;
 	private InvocationListener invocationListener = null;
 	private HttpStatusCodeProvider httpStatusCodeProvider = null;
 	private ConvertedParameterTransformer convertedParameterTransformer = null;
@@ -195,6 +196,7 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 		builder.addPropertyValue("rethrowExceptions", rethrowExceptions);
 		builder.addPropertyValue("allowExtraParams", allowExtraParams);
 		builder.addPropertyValue("allowLessParams", allowLessParams);
+		builder.addPropertyValue("shouldLogInvocationErrors", shouldLogInvocationErrors);
 
 		defaultListableBeanFactory.registerBeanDefinition(servicePath, builder.getBeanDefinition());
 	}
@@ -291,4 +293,9 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 	public void setConvertedParameterTransformer(ConvertedParameterTransformer convertedParameterTransformer) {
 		this.convertedParameterTransformer = convertedParameterTransformer;
 	}
+
+	public void setShouldLogInvocationErrors(boolean shouldLogInvocationErrors) {
+		this.shouldLogInvocationErrors = shouldLogInvocationErrors;
+	}
+
 }


### PR DESCRIPTION
# Logging Error Envelopes

In `JsonRpcBasicServer#writeAndFlushValueError(..)` it should not be logging the error envelope at 'warn' level because it is debug level logging intended to show the envelope payload.  Also, the full log message is always generated as a full string whereas it should be using interpolation to avoid creating the full log message string if the log level is disabled.

# Controlling Logging of Error Invocations

Previously, the system used JULI logging and it was possible to control the level of the logging for invocation exceptions.  With the move to SLF4J this is no longer possible and it seems to have changed to always log at warn level.  This is a problem in a system where errors returned to clients through JSON-RPC is 'main flow' and it is not desirable to log those with full strack traces at warn level.

In such a case, this patch adds a flag to control if those invocation errors should be logged at all.  If finer-grained exception logging is required, this can be achieved by employing an implementation of `InvocationListener`.