### PR TITLE
Custom Content-Type Header for Client and Server

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpClient.java
@@ -37,6 +37,7 @@ public class JsonRpcHttpClient extends JsonRpcClient implements IJsonRpcClient {
 	private int readTimeoutMillis = 60 * 1000 * 2;
 	private SSLContext sslContext = null;
 	private HostnameVerifier hostNameVerifier = null;
+	private String contentType = JSONRPC_CONTENT_TYPE;
 
 	/**
 	 * Creates the {@link JsonRpcHttpClient} bound to the given {@code serviceUrl}.
@@ -202,7 +203,7 @@ public class JsonRpcHttpClient extends JsonRpcClient implements IJsonRpcClient {
 	}
 
 	private void addHeaders(Map<String, String> extraHeaders, HttpURLConnection connection) {
-		connection.setRequestProperty("Content-Type", JSONRPC_CONTENT_TYPE);
+		connection.setRequestProperty("Content-Type", contentType);
 		for (Entry<String, String> entry : headers.entrySet()) {
 			connection.setRequestProperty(entry.getKey(), entry.getValue());
 		}
@@ -294,6 +295,13 @@ public class JsonRpcHttpClient extends JsonRpcClient implements IJsonRpcClient {
 	 */
 	public void setHostNameVerifier(HostnameVerifier hostNameVerifier) {
 		this.hostNameVerifier = hostNameVerifier;
+	}
+
+	/**
+	 * @param contentType the contentType to set
+	 */
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
 	}
 
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -23,6 +23,8 @@ import javax.portlet.ResourceResponse;
 public class JsonRpcServer extends JsonRpcBasicServer {
 	private static final Logger logger = LoggerFactory.getLogger(JsonRpcServer.class);
 
+	private String contentType = JSONRPC_CONTENT_TYPE;
+
 	/**
 	 * Creates the server with the given {@link ObjectMapper} delegating
 	 * all calls to the given {@code handler} {@link Object} but only
@@ -78,7 +80,7 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 	 */
 	public void handle(ResourceRequest request, ResourceResponse response) throws IOException {
 		logger.debug("Handing ResourceRequest {}", request.getMethod());
-		response.setContentType(JSONRPC_CONTENT_TYPE);
+		response.setContentType(contentType);
 		InputStream input = getRequestStream(request);
 		OutputStream output = response.getPortletOutputStream();
 		handleRequest(input, output);
@@ -109,7 +111,7 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 	 */
 	public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
 		logger.debug("Handling HttpServletRequest {}", request);
-		response.setContentType(JSONRPC_CONTENT_TYPE);
+		response.setContentType(contentType);
 		OutputStream output = response.getOutputStream();
 		InputStream input = getRequestStream(request);
 		int result = handleRequest(input, output);
@@ -133,6 +135,10 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 
 	private static InputStream createInputStream(HttpServletRequest request) throws IOException {
 		return createInputStream(request.getParameter(METHOD), request.getParameter(ID), request.getParameter(PARAMS));
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
 	}
 
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
@@ -36,6 +36,7 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 	private InvocationListener invocationListener = null;
 	private HttpStatusCodeProvider httpStatusCodeProvider = null;
 	private ConvertedParameterTransformer convertedParameterTransformer = null;
+	private String contentType = null;
 
 	/**
 	 * {@inheritDoc}
@@ -72,7 +73,6 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 		jsonRpcServer.setInvocationListener(invocationListener);
 		jsonRpcServer.setHttpStatusCodeProvider(httpStatusCodeProvider);
 		jsonRpcServer.setConvertedParameterTransformer(convertedParameterTransformer);
-		jsonRpcServer.setShouldLogInvocationErrors(shouldLogInvocationErrors);
 
 		exportService();
 	}
@@ -181,4 +181,9 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 	public void setShouldLogInvocationErrors(boolean shouldLogInvocationErrors) {
 		this.shouldLogInvocationErrors = shouldLogInvocationErrors;
 	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractJsonServiceExporter.java
@@ -73,6 +73,11 @@ abstract class AbstractJsonServiceExporter extends RemoteExporter implements Ini
 		jsonRpcServer.setInvocationListener(invocationListener);
 		jsonRpcServer.setHttpStatusCodeProvider(httpStatusCodeProvider);
 		jsonRpcServer.setConvertedParameterTransformer(convertedParameterTransformer);
+		jsonRpcServer.setShouldLogInvocationErrors(shouldLogInvocationErrors);
+
+		if (contentType != null) {
+			jsonRpcServer.setContentType(contentType);
+		}
 
 		exportService();
 	}

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcClientProxyCreator.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcClientProxyCreator.java
@@ -38,6 +38,7 @@ public class AutoJsonRpcClientProxyCreator implements BeanFactoryPostProcessor, 
 	private String scanPackage;
 	private URL baseUrl;
 	private ObjectMapper objectMapper;
+	private String contentType;
 
 	@Override
 	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
@@ -80,9 +81,15 @@ public class AutoJsonRpcClientProxyCreator implements BeanFactoryPostProcessor, 
 				.rootBeanDefinition(JsonProxyFactoryBean.class)
 				.addPropertyValue("serviceUrl", appendBasePath(path))
 				.addPropertyValue("serviceInterface", className);
+
 		if (objectMapper != null) {
 			beanDefinitionBuilder.addPropertyValue("objectMapper", objectMapper);
 		}
+
+		if (contentType != null) {
+			beanDefinitionBuilder.addPropertyValue("contentType", contentType);
+		}
+
 		defaultListableBeanFactory.registerBeanDefinition(className + "-clientProxy", beanDefinitionBuilder.getBeanDefinition());
 	}
 
@@ -112,5 +119,9 @@ public class AutoJsonRpcClientProxyCreator implements BeanFactoryPostProcessor, 
 
 	public void setObjectMapper(ObjectMapper objectMapper) {
 		this.objectMapper = objectMapper;
+	}
+
+	public void setContentType(String contextType) {
+		this.contentType = contextType;
 	}
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
@@ -72,6 +72,7 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 	private InvocationListener invocationListener = null;
 	private HttpStatusCodeProvider httpStatusCodeProvider = null;
 	private ConvertedParameterTransformer convertedParameterTransformer = null;
+	private String contentType = null;
 
 	/**
 	 * Finds the beans to expose.
@@ -192,6 +193,10 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 			builder.addPropertyValue("convertedParameterTransformer", convertedParameterTransformer);
 		}
 
+		if (contentType != null) {
+			builder.addPropertyValue("contentType", contentType);
+		}
+
 		builder.addPropertyValue("backwardsCompatible", backwardsCompatible);
 		builder.addPropertyValue("rethrowExceptions", rethrowExceptions);
 		builder.addPropertyValue("allowExtraParams", allowExtraParams);
@@ -287,7 +292,6 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 	}
 
 	/**
-	 *
 	 * @param convertedParameterTransformer the convertedParameterTransformer to set
 	 */
 	public void setConvertedParameterTransformer(ConvertedParameterTransformer convertedParameterTransformer) {
@@ -296,6 +300,10 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 
 	public void setShouldLogInvocationErrors(boolean shouldLogInvocationErrors) {
 		this.shouldLogInvocationErrors = shouldLogInvocationErrors;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
 	}
 
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/JsonProxyFactoryBean.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/JsonProxyFactoryBean.java
@@ -39,6 +39,7 @@ class JsonProxyFactoryBean extends UrlBasedRemoteAccessor implements MethodInter
 	private ObjectMapper objectMapper = null;
 	private JsonRpcHttpClient jsonRpcHttpClient = null;
 	private Map<String, String> extraHttpHeaders = new HashMap<>();
+	private String contentType;
 
 	private SSLContext sslContext = null;
 	private HostnameVerifier hostNameVerifier = null;
@@ -73,6 +74,10 @@ class JsonProxyFactoryBean extends UrlBasedRemoteAccessor implements MethodInter
 			jsonRpcHttpClient.setRequestListener(requestListener);
 			jsonRpcHttpClient.setSslContext(sslContext);
 			jsonRpcHttpClient.setHostNameVerifier(hostNameVerifier);
+
+			if (contentType != null) {
+				jsonRpcHttpClient.setContentType(contentType);
+			}
 		} catch (MalformedURLException mue) {
 			throw new RuntimeException(mue);
 		}
@@ -160,4 +165,10 @@ class JsonProxyFactoryBean extends UrlBasedRemoteAccessor implements MethodInter
 		this.hostNameVerifier = hostNameVerifier;
 	}
 
+	/**
+	 * @param contentType the contentType to pass to JsonRpcClient
+	 */
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
@@ -92,6 +92,25 @@ public class JsonRpcServerTest {
 	}
 
 	@Test
+	public void test_contentType() throws Exception {
+		EasyMock.expect(mockService.testMethod("Whir?inaki")).andReturn("For?est");
+		EasyMock.replay(mockService);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/test-post");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		request.setContentType("application/json");
+		request.setContent("{\"jsonrpc\":\"2.0\",\"id\":123,\"method\":\"testMethod\",\"params\":[\"Whir?inaki\"]}".getBytes(StandardCharsets.UTF_8));
+
+		jsonRpcServer.setContentType("flip/flop");
+
+		jsonRpcServer.handle(request, response);
+
+		assertTrue("flip/flop".equals(response.getContentType()));
+		checkSuccessfulResponse(response);
+	}
+
+	@Test
 	public void testGetMethod_base64Params() throws Exception {
 		EasyMock.expect(mockService.testMethod("Whir?inaki")).andReturn("For?est");
 		EasyMock.replay(mockService);
@@ -105,6 +124,7 @@ public class JsonRpcServerTest {
 
 		jsonRpcServer.handle(request, response);
 
+		assertTrue("application/json-rpc".equals(response.getContentType()));
 		checkSuccessfulResponse(response);
 	}
 
@@ -122,6 +142,7 @@ public class JsonRpcServerTest {
 
 		jsonRpcServer.handle(request, response);
 
+		assertTrue("application/json-rpc".equals(response.getContentType()));
 		checkSuccessfulResponse(response);
 	}
 

--- a/src/test/resources/clientApplicationContext.xml
+++ b/src/test/resources/clientApplicationContext.xml
@@ -4,6 +4,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
   <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcClientProxyCreator"
+        p:contentType="ding/dong"
     p:baseUrl="http://localhost:8080/the-context/"
     p:scanPackage="com.googlecode.jsonrpc4j.spring.service" />
 

--- a/src/test/resources/serverApplicationContextB.xml
+++ b/src/test/resources/serverApplicationContextB.xml
@@ -4,6 +4,8 @@
 
     <bean class="com.googlecode.jsonrpc4j.spring.serviceb.TemperatureImpl"/>
     <bean class="com.googlecode.jsonrpc4j.spring.serviceb.NoopTemperatureImpl"/>
-    <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImplExporter"/>
+    <bean class="com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImplExporter">
+        <property name="contentType" value="ding/dong"/>
+    </bean>
 
 </beans>


### PR DESCRIPTION
This resolves issue #144.  It should now be possible to configure a custom Content-Type on the server as well as the client.