### PR TITLE
Handling of empty requests

### DIFF
--- a/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
@@ -125,6 +125,15 @@ public class JsonRpcServerTest {
 		checkSuccessfulResponse(response);
 	}
 
+	@Test
+	public void testNullRequest() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test-get");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		jsonRpcServer.handle(request, response);
+		assertTrue(MockHttpServletResponse.SC_BAD_REQUEST == response.getStatus());
+	}
+
 	// Service and service interfaces used in test
 
 	public interface ServiceInterface {


### PR DESCRIPTION
Added handling of requests where no request is sent. Instead of ISE 500 an error 400 is returned