### PR TITLE
Fixed client exception handling for JSON-RPC over String RestTemplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tmp/
 .project
 .settings/
 /bin/
+/.nb-gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 description = 'This project aims to provide the facility to easily implement JSON-RPC for the java programming language.'
-version = '1.4.4'
+version = '1.4.5-SNAPSHOT'
 group = 'com.github.briandilley.jsonrpc4j'
 
 sourceCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 description = 'This project aims to provide the facility to easily implement JSON-RPC for the java programming language.'
-version = '1.4.5-SNAPSHOT'
+version = '1.4.4'
 group = 'com.github.briandilley.jsonrpc4j'
 
 sourceCompatibility = 1.7

--- a/src/main/java/com/googlecode/jsonrpc4j/DefaultHttpStatusCodeProvider.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/DefaultHttpStatusCodeProvider.java
@@ -9,10 +9,9 @@ import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.INVALID_REQUEST;
 import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.METHOD_NOT_FOUND;
 import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.METHOD_PARAMS_INVALID;
 import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.PARSE_ERROR;
+import java.net.HttpURLConnection;
 
 import java.util.Arrays;
-
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * This default implementation of a {@link HttpStatusCodeProvider} follows the rules defined in the
@@ -24,15 +23,15 @@ public enum DefaultHttpStatusCodeProvider implements HttpStatusCodeProvider {
 
 	@Override
 	public int getHttpStatusCode(int resultCode) {
-		if (resultCode == 0) return HttpServletResponse.SC_OK;
+		if (resultCode == 0) return HttpURLConnection.HTTP_OK; // Toha: pure java constants
 
 		if (isErrorCode(resultCode)) {
-			return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+			return HttpURLConnection.HTTP_INTERNAL_ERROR;
 		} else if (resultCode == INVALID_REQUEST.code || resultCode == PARSE_ERROR.code) {
-			return HttpServletResponse.SC_BAD_REQUEST;
-		} else if (resultCode == METHOD_NOT_FOUND.code) { return HttpServletResponse.SC_NOT_FOUND; }
+			return HttpURLConnection.HTTP_BAD_REQUEST;
+		} else if (resultCode == METHOD_NOT_FOUND.code) { return HttpURLConnection.HTTP_NOT_FOUND; }
 
-		return HttpServletResponse.SC_OK;
+		return HttpURLConnection.HTTP_OK;
 	}
 
 	private boolean isErrorCode(int result) {

--- a/src/main/java/com/googlecode/jsonrpc4j/DefaultHttpStatusCodeProvider.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/DefaultHttpStatusCodeProvider.java
@@ -12,6 +12,8 @@ import static com.googlecode.jsonrpc4j.ErrorResolver.JsonError.PARSE_ERROR;
 import java.net.HttpURLConnection;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This default implementation of a {@link HttpStatusCodeProvider} follows the rules defined in the
@@ -21,6 +23,16 @@ import java.util.Arrays;
 public enum DefaultHttpStatusCodeProvider implements HttpStatusCodeProvider {
 	INSTANCE;
 
+	final Map<Integer, ErrorResolver.JsonError> httpStatus2JsonError = new HashMap<Integer, ErrorResolver.JsonError>();
+
+	private DefaultHttpStatusCodeProvider()
+	{
+		httpStatus2JsonError.put(HttpURLConnection.HTTP_INTERNAL_ERROR, INTERNAL_ERROR);
+		httpStatus2JsonError.put(HttpURLConnection.HTTP_NOT_FOUND,		METHOD_NOT_FOUND);
+		httpStatus2JsonError.put(HttpURLConnection.HTTP_BAD_REQUEST,    PARSE_ERROR);
+	}
+	
+	
 	@Override
 	public int getHttpStatusCode(int resultCode) {
 		if (resultCode == 0) return HttpURLConnection.HTTP_OK; // Toha: pure java constants
@@ -39,5 +51,13 @@ public enum DefaultHttpStatusCodeProvider implements HttpStatusCodeProvider {
 			if (error.code == result) return true;
 		}
 		return CUSTOM_SERVER_ERROR_UPPER >= result && result >= CUSTOM_SERVER_ERROR_LOWER;
+	}
+
+	@Override
+	public Integer getJsonRpcCode(int httpStatusCode)
+	{
+		return httpStatus2JsonError.containsKey(httpStatusCode) 
+			?  httpStatus2JsonError.get(httpStatusCode).getCode()
+			: null;
 	}
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/HttpStatusCodeProvider.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/HttpStatusCodeProvider.java
@@ -24,4 +24,13 @@ public interface HttpStatusCodeProvider {
 	 * @return the int representation of the HTTP status code that should be used by the JSON-RPC response.
 	 */
 	int getHttpStatusCode(int resultCode);
+	
+	/**
+	 * Returns result code for the given HTTP status code
+	 * @param httpStatusCode
+	 *		the int representation of the HTTP status code that should be used by the JSON-RPC response.
+	 * @return 
+	 *		resultCode the result code of the current JSON-RPC method call. This is used to look up the HTTP status
+	 */
+	Integer getJsonRpcCode(int httpStatusCode);
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -859,8 +859,8 @@ public class JsonRpcBasicServer {
 	 * logged together with the underlying stack trace.  When false, no error will be logged.
 	 * An alternative mechanism for logging invocation errors is to employ an implementation of
 	 * {@link InvocationListener}.
+	 * @param  shouldLogInvocationErrors see method description
 	 */
-
 	public void setShouldLogInvocationErrors(boolean shouldLogInvocationErrors) {
 		this.shouldLogInvocationErrors = shouldLogInvocationErrors;
 	}

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -541,13 +541,14 @@ public class JsonRpcClient {
 	}
 
 	// Suppose than jsonObject is single and contains valid id :)
-	protected Object readResponse(Type returnType, ObjectNode jsonObject) throws Throwable {
+	protected Object readResponse(Type returnType, JsonNode jsonObject) throws Throwable {
 		return readResponse(returnType, jsonObject, null);
 	}
 
 	// Suppose than jsonObject is single and contains valid id :)
-	private Object readResponse(Type returnType, ObjectNode jsonObject, String id) throws Throwable {
-		raiseExceptionIfNotValidResponseObject(jsonObject);
+	private Object readResponse(Type returnType, JsonNode jsonNode, String id) throws Throwable {
+		raiseExceptionIfNotValidResponseObject(jsonNode);
+		final ObjectNode jsonObject = ObjectNode.class.cast(jsonNode);
 		notifyAnswerListener(jsonObject);
 		handleErrorResponse(jsonObject);
 		if (hasResult(jsonObject)) {

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -34,7 +34,8 @@ import java.util.Random;
 @SuppressWarnings({ "WeakerAccess", "unused" })
 public class JsonRpcClient {
 
-	private static final Logger logger = LoggerFactory.getLogger(JsonRpcClient.class);
+	// Toha: to use same logger in extension classes
+	protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
 	private final ObjectMapper mapper;
 	private final Random random;

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcResponseErrorHandler.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcResponseErrorHandler.java
@@ -39,14 +39,20 @@ public enum JsonRpcResponseErrorHandler
 	public boolean hasError(ClientHttpResponse response)
 		throws IOException
 	{
+		
 		final HttpStatus httpStatus = getHttpStatusCode(response);
 		
 		if (JSON_RPC_STATUES.contains(httpStatus.value()))
-			return false;
-		else 
-			return 
-				httpStatus.series() == HttpStatus.Series.CLIENT_ERROR ||
-				httpStatus.series() == HttpStatus.Series.SERVER_ERROR;
+		{
+			// Checks the content type. If application/json-rpc then allow handler to read message
+			final MediaType contentType =  response.getHeaders().getContentType();
+			if (MappingJacksonRPC2HttpMessageConverter.APPLICATION_JSON_RPC.isCompatibleWith(contentType))
+				return true;
+		}
+		
+		return 
+			httpStatus.series() == HttpStatus.Series.CLIENT_ERROR ||
+			httpStatus.series() == HttpStatus.Series.SERVER_ERROR;
 	}
 
 	@Override

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcResponseErrorHandler.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcResponseErrorHandler.java
@@ -1,0 +1,102 @@
+package com.googlecode.jsonrpc4j.spring.rest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.UnknownHttpStatusCodeException;
+
+public enum JsonRpcResponseErrorHandler
+	implements ResponseErrorHandler {
+
+	INSTANCE;
+	
+	/**
+	 * for supported codes see {@link com.googlecode.jsonrpc4j.DefaultHttpStatusCodeProvider}
+	 */
+	private final Set<Integer> JSON_RPC_STATUES = new HashSet<Integer>();
+	
+	
+	private JsonRpcResponseErrorHandler()
+	{
+		JSON_RPC_STATUES.add(HttpURLConnection.HTTP_INTERNAL_ERROR);
+		JSON_RPC_STATUES.add(HttpURLConnection.HTTP_BAD_REQUEST);
+		JSON_RPC_STATUES.add(HttpURLConnection.HTTP_NOT_FOUND);
+	}
+	
+	@Override
+	public boolean hasError(ClientHttpResponse response)
+		throws IOException
+	{
+		final HttpStatus httpStatus = getHttpStatusCode(response);
+		
+		if (JSON_RPC_STATUES.contains(httpStatus.value()))
+			return false;
+		else 
+			return 
+				httpStatus.series() == HttpStatus.Series.CLIENT_ERROR ||
+				httpStatus.series() == HttpStatus.Series.SERVER_ERROR;
+	}
+
+	@Override
+	public void handleError(ClientHttpResponse response)
+		throws IOException
+	{
+		final HttpStatus statusCode = getHttpStatusCode(response);
+		
+		switch (statusCode.series()) {
+			case CLIENT_ERROR:
+				throw new HttpClientErrorException(statusCode, response.getStatusText(),
+						response.getHeaders(), getResponseBody(response), getCharset(response));
+			case SERVER_ERROR:
+				throw new HttpServerErrorException(statusCode, response.getStatusText(),
+						response.getHeaders(), getResponseBody(response), getCharset(response));
+			default:
+				throw new RestClientException("Unknown status code [" + statusCode + "]");
+		}
+	}
+	
+	
+	private HttpStatus getHttpStatusCode(ClientHttpResponse response) throws IOException {
+		final HttpStatus statusCode;
+		try {
+			statusCode = response.getStatusCode();
+		}
+		catch (IllegalArgumentException ex) {
+			throw new UnknownHttpStatusCodeException(response.getRawStatusCode(),
+					response.getStatusText(), response.getHeaders(), getResponseBody(response), getCharset(response));
+		}
+		return statusCode;
+	}
+
+	private byte[] getResponseBody(ClientHttpResponse response) {
+		try {
+			final InputStream responseBody = response.getBody();
+			if (responseBody != null) {
+				return FileCopyUtils.copyToByteArray(responseBody);
+			}
+		}
+		catch (IOException ex) {
+			throw new RuntimeException(ex.getMessage(), ex);
+		}
+		return new byte[0];
+	}
+
+	private Charset getCharset(ClientHttpResponse response) {
+		HttpHeaders headers = response.getHeaders();
+		MediaType contentType = headers.getContentType();
+		return contentType != null ? contentType.getCharSet() : null;
+	}
+	
+}

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcRestClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcRestClient.java
@@ -1,5 +1,6 @@
 package com.googlecode.jsonrpc4j.spring.rest;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.util.LinkedMultiValueMap;
@@ -11,6 +12,7 @@ import com.googlecode.jsonrpc4j.JsonRpcClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.googlecode.jsonrpc4j.JsonRpcClientException;
 
 import java.lang.reflect.Type;
 import java.net.Proxy;
@@ -23,16 +25,18 @@ import java.util.Map;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.web.client.HttpStatusCodeException;
 
 @SuppressWarnings({ "unused", "WeakerAccess" })
 public class JsonRpcRestClient extends JsonRpcClient implements IJsonRpcClient {
 
 	private final URL serviceUrl;
-	private final RestTemplate restTemplate;
+	private final RestTemplate  restTemplate;
 
 	private final Map<String, String> headers = new HashMap<>();
 
-	private SslClientHttpRequestFactory requestFactory = null;
+	private final SslClientHttpRequestFactory requestFactory;
 
 	public JsonRpcRestClient(URL serviceUrl) {
 		this(serviceUrl, new ObjectMapper());
@@ -45,7 +49,8 @@ public class JsonRpcRestClient extends JsonRpcClient implements IJsonRpcClient {
 	@SuppressWarnings("WeakerAccess")
 	public JsonRpcRestClient(URL serviceUrl, ObjectMapper mapper, RestTemplate restTemplate, Map<String, String> headers) {
 		super(mapper);
-		this.restTemplate = restTemplate != null ? restTemplate : new RestTemplate();
+		this.requestFactory = restTemplate != null ? null         : new SslClientHttpRequestFactory();
+		this.restTemplate   = restTemplate != null ? restTemplate : new RestTemplate(this.requestFactory);
 		this.serviceUrl = serviceUrl;
 
 		if (headers != null) {
@@ -83,6 +88,9 @@ public class JsonRpcRestClient extends JsonRpcClient implements IJsonRpcClient {
 			this.restTemplate.setMessageConverters(restMessageConverters);
 		}
 
+		// use specific JSON-RPC erro handler
+		if (!(restTemplate.getErrorHandler() instanceof JsonRpcResponseErrorHandler))
+			restTemplate.setErrorHandler(JsonRpcResponseErrorHandler.INSTANCE);
 	}
 
 	public JsonRpcRestClient(URL serviceUrl, Map<String, String> headers) {
@@ -106,8 +114,8 @@ public class JsonRpcRestClient extends JsonRpcClient implements IJsonRpcClient {
 
 	private SslClientHttpRequestFactory getRequestFactory() {
 		if (this.requestFactory == null) {
-			this.requestFactory = new SslClientHttpRequestFactory();
-		}
+			throw new IllegalStateException("Used external RequestTemplate instance");
+        }
 		return requestFactory;
 	}
 
@@ -181,7 +189,7 @@ public class JsonRpcRestClient extends JsonRpcClient implements IJsonRpcClient {
 	public Object invoke(String methodName, Object argument, Type returnType, Map<String, String> extraHeaders) throws Throwable {
 
 		final ObjectNode request = super.createRequest(methodName, argument);
-		MultiValueMap<String, String> httpHeaders = new LinkedMultiValueMap<>();
+		final MultiValueMap<String, String> httpHeaders = new LinkedMultiValueMap<>();
 
 		for (Map.Entry<String, String> entry : this.headers.entrySet()) {
 			httpHeaders.add(entry.getKey(), entry.getValue());
@@ -193,14 +201,23 @@ public class JsonRpcRestClient extends JsonRpcClient implements IJsonRpcClient {
 			}
 		}
 
-		// NB: Too bad code. May be it is better to always use external requestFactory?
-		// im-scooter: It seems to be good idea to delegate all communications to RestTemplate....
-		if (this.requestFactory != null && restTemplate.getRequestFactory() != this.requestFactory) {
-			this.restTemplate.setRequestFactory(this.requestFactory);
-		}
-
 		final HttpEntity<ObjectNode> requestHttpEntity = new HttpEntity<>(request, httpHeaders);
-		ObjectNode response = this.restTemplate.postForObject(serviceUrl.toExternalForm(), requestHttpEntity, ObjectNode.class);
+		ObjectNode response;
+		try {
+			response = this.restTemplate.postForObject(serviceUrl.toExternalForm(), requestHttpEntity, ObjectNode.class);
+		} catch (HttpStatusCodeException httpStatusCodeException) {
+			 logger.error("HTTP Error code={} status={}\nresponse={}"
+				 ,  httpStatusCodeException.getStatusCode().value()
+				 , httpStatusCodeException.getStatusText()
+				 , httpStatusCodeException.getResponseBodyAsString()
+			 );
+			 final JsonNode jsonNode = getObjectMapper().readValue(httpStatusCodeException.getResponseBodyAsString(), JsonNode.class);
+			 throw new JsonRpcClientException(0, "Invalid JSON-RPC response", jsonNode);
+		} catch (HttpMessageConversionException httpMessageConversionException) {
+			logger.error("Can not convert (request/response)", httpMessageConversionException);
+			throw new  JsonRpcClientException(0, "Invalid JSON-RPC response", null);
+		}
+		
 		return this.readResponse(returnType, response);
 	}
 

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcRestClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcRestClient.java
@@ -12,6 +12,7 @@ import com.googlecode.jsonrpc4j.JsonRpcClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.googlecode.jsonrpc4j.DefaultHttpStatusCodeProvider;
 import com.googlecode.jsonrpc4j.JsonRpcClientException;
 
 import java.lang.reflect.Type;
@@ -224,7 +225,10 @@ public class JsonRpcRestClient extends JsonRpcClient implements IJsonRpcClient {
 				 , httpStatusCodeException.getStatusText()
 				 , httpStatusCodeException.getResponseBodyAsString()
 			 );
-			 throw new JsonRpcClientException(0, "Invalid JSON-RPC response", null);
+			 Integer jsonErrorCode = DefaultHttpStatusCodeProvider.INSTANCE.getJsonRpcCode(httpStatusCodeException.getStatusCode().value());
+			 if (jsonErrorCode==null)
+				 jsonErrorCode = httpStatusCodeException.getStatusCode().value();
+			 throw new JsonRpcClientException(jsonErrorCode, httpStatusCodeException.getStatusText(), null);
 		} catch (HttpMessageConversionException httpMessageConversionException) {
 			logger.error("Can not convert (request/response)", httpMessageConversionException);
 			throw new  JsonRpcClientException(0, "Invalid JSON-RPC response", null);

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/rest/MappingJacksonRPC2HttpMessageConverter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/rest/MappingJacksonRPC2HttpMessageConverter.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * JSON-RPC Message converter for Spring RestTemplate
@@ -23,7 +24,7 @@ import java.nio.charset.Charset;
 @SuppressWarnings({ "WeakerAccess", "unused" })
 class MappingJacksonRPC2HttpMessageConverter extends AbstractHttpMessageConverter<Object> {
 
-	private static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
+	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 	private static final MediaType APPLICATION_JSON_RPC = new MediaType("application", "json-rpc", DEFAULT_CHARSET);
 
 	private ObjectMapper objectMapper;
@@ -139,9 +140,8 @@ class MappingJacksonRPC2HttpMessageConverter extends AbstractHttpMessageConverte
 	protected void writeInternal(Object object, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException {
 
-		JsonEncoding encoding = getJsonEncoding(outputMessage.getHeaders().getContentType());
-
-		JsonGenerator jsonGenerator = this.objectMapper.getFactory().createGenerator(outputMessage.getBody(), encoding);
+		final JsonEncoding encoding = getJsonEncoding(outputMessage.getHeaders().getContentType());
+		final JsonGenerator jsonGenerator = this.objectMapper.getFactory().createGenerator(outputMessage.getBody(), encoding);
 		try {
 			if (this.prefixJson) {
 				jsonGenerator.writeRaw("{} && ");

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/rest/MappingJacksonRPC2HttpMessageConverter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/rest/MappingJacksonRPC2HttpMessageConverter.java
@@ -11,6 +11,7 @@ import org.springframework.util.Assert;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -25,7 +26,7 @@ import java.nio.charset.StandardCharsets;
 class MappingJacksonRPC2HttpMessageConverter extends AbstractHttpMessageConverter<Object> {
 
 	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
-	private static final MediaType APPLICATION_JSON_RPC = new MediaType("application", "json-rpc", DEFAULT_CHARSET);
+	public static final MediaType APPLICATION_JSON_RPC = new MediaType("application", "json-rpc", DEFAULT_CHARSET);
 
 	private ObjectMapper objectMapper;
 
@@ -92,7 +93,7 @@ class MappingJacksonRPC2HttpMessageConverter extends AbstractHttpMessageConverte
 	@Override
 	public boolean canRead(Class<?> clazz, MediaType mediaType) {
 
-		if (!ObjectNode.class.isAssignableFrom(clazz)) { return false; }
+		if (!JsonNode.class.isAssignableFrom(clazz)) { return false; }
 
 		if (mediaType == null) { return true; }
 

--- a/src/test/java/com/googlecode/jsonrpc4j/server/HttpStatusCodeProviderTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/HttpStatusCodeProviderTest.java
@@ -55,7 +55,14 @@ public class HttpStatusCodeProviderTest {
 						return 1000;
 				}
 			}
+
+			@Override
+			public Integer getJsonRpcCode(int httpStatusCode)
+			{
+				return null;
+			}
 		};
+		
 		jsonRpcServer.setHttpStatusCodeProvider(httpStatusCodeProvider);
 	}
 

--- a/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
@@ -69,7 +69,7 @@ public class JsonRpcServerTest {
 
 		request.addParameter("id", Integer.toString(123));
 		// no method!
-		request.addParameter("params", net.iharder.Base64.encodeBytes(("[\"Whirinaki\"]").getBytes(StandardCharsets.UTF_8)));
+		request.addParameter("params", net.iharder.Base64.encodeBytes("[\"Whirinaki\"]".getBytes(StandardCharsets.UTF_8)));
 
 		jsonRpcServer.handle(request, response);
 
@@ -101,7 +101,7 @@ public class JsonRpcServerTest {
 
 		request.addParameter("id", Integer.toString(123));
 		request.addParameter("method", "testMethod");
-		request.addParameter("params", net.iharder.Base64.encodeBytes(("[\"Whir?inaki\"]").getBytes(StandardCharsets.UTF_8)));
+		request.addParameter("params", net.iharder.Base64.encodeBytes("[\"Whir?inaki\"]".getBytes(StandardCharsets.UTF_8)));
 
 		jsonRpcServer.handle(request, response);
 


### PR DESCRIPTION
Hi! 
I tried to use jsonrpc4j 1.4.4 for my code created for 1.2.0. Unfortunately old (1.2.0) implementation of JsonRpcRestClient  class can't correctly process new mode of checked exception transition because HTTP status code used for that  differs from HTTP_OK.
In branch I 
1. tried to fix this problem
2.  added some http status code translation to json-rpc response code
3.  fixed my some old ugly code snippets