### PR TITLE
Allows client to use different id generation strategy. 

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -39,6 +39,7 @@ public class JsonRpcClient {
 	private final ObjectMapper mapper;
 	private final Random random;
 	private RequestListener requestListener;
+	private RequestIDGenerator requestIDGenerator;
 	private ExceptionResolver exceptionResolver = DefaultExceptionResolver.INSTANCE;
 	private Map<String, Object> additionalJsonContent = new HashMap<>();
 
@@ -58,6 +59,7 @@ public class JsonRpcClient {
 	public JsonRpcClient(ObjectMapper mapper) {
 		this.mapper = mapper;
 		this.random = new Random(System.currentTimeMillis());
+        this.requestIDGenerator = new RandomRequestIDGenerator();
 	}
 
 	public Map<String, Object> getAdditionalJsonContent() {
@@ -75,6 +77,15 @@ public class JsonRpcClient {
 	public void setRequestListener(RequestListener requestListener) {
 		this.requestListener = requestListener;
 	}
+
+    /**
+     * Set the {@link RequestIDGenerator}
+     *
+     * @param requestIDGenerator the {@link RequestIDGenerator}
+     */
+    public void setRequestIDGenerator(RequestIDGenerator requestIDGenerator) {
+        this.requestIDGenerator = requestIDGenerator;
+    }
 
 	/**
 	 * Invokes the given method on the remote service
@@ -111,7 +122,7 @@ public class JsonRpcClient {
 	 * @throws Throwable on error
 	 */
 	public Object invokeAndReadResponse(String methodName, Object argument, Type returnType, OutputStream output, InputStream input) throws Throwable {
-		return invokeAndReadResponse(methodName, argument, returnType, output, input, generateRandomId());
+		return invokeAndReadResponse(methodName, argument, returnType, output, input, this.requestIDGenerator.generateID());
 	}
 
 	/**
@@ -453,7 +464,7 @@ public class JsonRpcClient {
 	 * @throws IOException on error
 	 */
 	public void invoke(String methodName, Object argument, OutputStream output) throws IOException {
-		invoke(methodName, argument, output, generateRandomId());
+		invoke(methodName, argument, output, this.requestIDGenerator.generateID());
 	}
 
 	/**
@@ -518,7 +529,7 @@ public class JsonRpcClient {
 	}
 
 	protected ObjectNode createRequest(String methodName, Object argument) {
-		return internalCreateRequest(methodName, argument, generateRandomId());
+		return internalCreateRequest(methodName, argument, this.requestIDGenerator.generateID());
 	}
 
 	public ObjectNode createRequest(String methodName, Object argument, String id) {
@@ -598,4 +609,14 @@ public class JsonRpcClient {
 		void onBeforeResponseProcessed(JsonRpcClient client, ObjectNode response);
 	}
 
+    /**
+     * Default generator which returns random generated request ID.
+     */
+    class RandomRequestIDGenerator implements RequestIDGenerator {
+
+        @Override
+        public String generateID() {
+            return generateRandomId();
+        }
+    }
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/RequestIDGenerator.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/RequestIDGenerator.java
@@ -1,0 +1,15 @@
+package com.googlecode.jsonrpc4j;
+
+/**
+ * Request ID generator interface. This allows {@link JsonRpcClient} to use different strategy to
+ * generate the ID for the request.
+ */
+public interface RequestIDGenerator {
+
+    /**
+     * Generate the request ID for each json-rpc request.
+     *
+     * @return The request id. This can be of any type. It is used to match the response with the request that it is replying to.
+     */
+    String generateID();
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/client/JsonRpcClientTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/client/JsonRpcClientTest.java
@@ -110,19 +110,19 @@ public class JsonRpcClientTest {
 
 	@Test
 	public void testRandomIDGeneration() throws IOException {
-		Map<String, Object> params = new HashMap<>();
-		params.put("hello", "test");
-		params.put("x", 1);
-		client.invoke("test", params, byteArrayOutputStream);
-		JsonNode node = readJSON(byteArrayOutputStream);
+        Map<String, Object> params = new HashMap<>();
+        params.put("hello", "test");
+        params.put("x", 1);
+        client.invoke("test", params, byteArrayOutputStream);
+        JsonNode node = readJSON(byteArrayOutputStream);
 
-		assertTrue(node.has(PARAMS));
-		assertTrue(node.get(PARAMS).isObject());
-		try {
-			long id = Long.parseLong(node.get(ID).asText());
-		} catch (NumberFormatException e) {
-			fail();
-		}
-	}
+        assertTrue(node.has(PARAMS));
+        assertTrue(node.get(PARAMS).isObject());
+        try {
+            Long.parseLong(node.get(ID).asText());
+        } catch (NumberFormatException e) {
+            fail();
+        }
+    }
 
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/client/JsonRpcClientTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/client/JsonRpcClientTest.java
@@ -110,19 +110,19 @@ public class JsonRpcClientTest {
 
 	@Test
 	public void testRandomIDGeneration() throws IOException {
-        Map<String, Object> params = new HashMap<>();
-        params.put("hello", "test");
-        params.put("x", 1);
-        client.invoke("test", params, byteArrayOutputStream);
-        JsonNode node = readJSON(byteArrayOutputStream);
+		Map<String, Object> params = new HashMap<>();
+		params.put("hello", "test");
+		params.put("x", 1);
+		client.invoke("test", params, byteArrayOutputStream);
+		JsonNode node = readJSON(byteArrayOutputStream);
 
-        assertTrue(node.has(PARAMS));
-        assertTrue(node.get(PARAMS).isObject());
-        try {
-            Long.parseLong(node.get(ID).asText());
-        } catch (NumberFormatException e) {
-            fail();
-        }
-    }
+		assertTrue(node.has(PARAMS));
+		assertTrue(node.get(PARAMS).isObject());
+		try {
+			Long.parseLong(node.get(ID).asText());
+		} catch (NumberFormatException e) {
+			fail();
+		}
+	}
 
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/client/JsonRpcClientTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/client/JsonRpcClientTest.java
@@ -1,10 +1,10 @@
 package com.googlecode.jsonrpc4j.client;
 
+import static com.googlecode.jsonrpc4j.JsonRpcBasicServer.ID;
 import static com.googlecode.jsonrpc4j.JsonRpcBasicServer.PARAMS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
+import com.googlecode.jsonrpc4j.RequestIDGenerator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -86,6 +86,43 @@ public class JsonRpcClientTest {
 		assertTrue(node.get(PARAMS).isObject());
 		assertEquals("test", node.get(PARAMS).get("hello").textValue());
 		assertEquals(1, node.get(PARAMS).get("x").intValue());
+	}
+
+	@Test
+	public void testIDGeneration() throws IOException {
+		client.setRequestIDGenerator(new RequestIDGenerator() {
+			@Override
+			public String generateID() {
+				return "test";
+			}
+		});
+
+		Map<String, Object> params = new HashMap<>();
+		params.put("hello", "test");
+		params.put("x", 1);
+		client.invoke("test", params, byteArrayOutputStream);
+		JsonNode node = readJSON(byteArrayOutputStream);
+
+		assertTrue(node.has(PARAMS));
+		assertTrue(node.get(PARAMS).isObject());
+		assertEquals("test", node.get(ID).asText());
+	}
+
+	@Test
+	public void testRandomIDGeneration() throws IOException {
+		Map<String, Object> params = new HashMap<>();
+		params.put("hello", "test");
+		params.put("x", 1);
+		client.invoke("test", params, byteArrayOutputStream);
+		JsonNode node = readJSON(byteArrayOutputStream);
+
+		assertTrue(node.has(PARAMS));
+		assertTrue(node.get(PARAMS).isObject());
+		try {
+			long id = Long.parseLong(node.get(ID).asText());
+		} catch (NumberFormatException e) {
+			fail();
+		}
 	}
 
 }


### PR DESCRIPTION
Hi @briandilley ,

We have a requirement to send a fix id in each json rpc request. It is used to be possible to achieve it through overriding one of the methods in the super class (JsonRpcClient.java), however, this is no longer possible in the latest release.  please refer to https://github.com/briandilley/jsonrpc4j/issues/154 for more details. 

I've added support for different id generation strategy in the JsonRpcClient class. This allows the client to use a strategy of their choice other than the default one. If client doesn't provide one, it defaults to the random generation. 

Can you please review and see this is ok to be merged.

Thanks