### PR TITLE
Added support for Gzipping request and response

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -56,6 +56,8 @@ public class JsonRpcBasicServer {
 	public static final String METHOD = "method";
 	public static final String JSONRPC = "jsonrpc";
 	public static final String ID = "id";
+	public static final String CONTENT_ENCODING = "Content-Encoding";
+	public static final String ACCEPT_ENCODING = "Accept-Encoding";
 
 	public static final String ERROR = "error";
 	public static final String ERROR_MESSAGE = "message";

--- a/src/test/java/com/googlecode/jsonrpc4j/integration/HttpClientTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/integration/HttpClientTest.java
@@ -1,0 +1,45 @@
+package com.googlecode.jsonrpc4j.integration;
+
+import com.googlecode.jsonrpc4j.ProxyUtil;
+import com.googlecode.jsonrpc4j.util.BaseRestTest;
+import com.googlecode.jsonrpc4j.util.FakeServiceInterface;
+import com.googlecode.jsonrpc4j.util.FakeServiceInterfaceImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+
+/**
+ * HttpClientTest
+ */
+public class HttpClientTest extends BaseRestTest {
+
+    private FakeServiceInterface service;
+
+    @Test
+    public void testGZIPRequest() throws MalformedURLException {
+        service = ProxyUtil.createClientProxy(this.getClass().getClassLoader(), FakeServiceInterface.class, getHttpClient(true, false));
+        int i = service.returnPrimitiveInt(2);
+        Assert.assertEquals(2, i);
+    }
+
+    @Test
+    public void testGZIPRequestAndResponse() throws MalformedURLException {
+        service = ProxyUtil.createClientProxy(this.getClass().getClassLoader(), FakeServiceInterface.class, getHttpClient(true, true));
+        int i = service.returnPrimitiveInt(2);
+        Assert.assertEquals(2, i);
+    }
+
+    @Test
+    public void testRequestAndResponse() throws MalformedURLException {
+        service = ProxyUtil.createClientProxy(this.getClass().getClassLoader(), FakeServiceInterface.class, getHttpClient(false, false));
+        int i = service.returnPrimitiveInt(2);
+        Assert.assertEquals(2, i);
+    }
+
+    @Override
+    protected Class service() {
+        return FakeServiceInterfaceImpl.class;
+    }
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/util/BaseRestTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/BaseRestTest.java
@@ -1,5 +1,7 @@
 package com.googlecode.jsonrpc4j.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -9,6 +11,8 @@ import com.googlecode.jsonrpc4j.spring.rest.JsonRpcRestClient;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class BaseRestTest {
 
@@ -33,6 +37,11 @@ public abstract class BaseRestTest {
 
 	protected JsonRpcRestClient getClient() throws MalformedURLException {
 		return getClient(JettyServer.SERVLET);
+	}
+
+	protected JsonRpcHttpClient getHttpClient(boolean gzipRequests, boolean acceptGzipResponses) throws MalformedURLException {
+		Map<String, String> header = new HashMap<>();
+		return new JsonRpcHttpClient(new ObjectMapper(), new URL(jettyServer.getCustomServerUrlString(JettyServer.SERVLET)), header, gzipRequests, acceptGzipResponses);
 	}
 
 	protected JsonRpcRestClient getClient(final String servlet) throws MalformedURLException {


### PR DESCRIPTION
To support issue: https://github.com/briandilley/jsonrpc4j/issues/155

JsonRpcServer now is able to communicate with client using gzip bidirectionaly.
JsonRpcHttpClient now is able to gzip request.
