### PR TITLE
JsonMappingException was masked by IOException

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpClient.java
@@ -2,6 +2,7 @@ package com.googlecode.jsonrpc4j;
 
 import static com.googlecode.jsonrpc4j.JsonRpcBasicServer.JSONRPC_CONTENT_TYPE;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.BufferedReader;
@@ -110,6 +111,9 @@ public class JsonRpcHttpClient extends JsonRpcClient implements IJsonRpcClient {
 				try (InputStream answer = getStream(connection.getInputStream(), useGzip)) {
 					return super.readResponse(returnType, answer);
 				}
+			} catch (JsonMappingException e) {
+				// JsonMappingException inherits from IOException
+				throw e;
 			} catch (IOException e) {
 				try (InputStream answer = getStream(connection.getErrorStream(), useGzip)) {
 					return super.readResponse(returnType, answer);


### PR DESCRIPTION
Hi,

I tried to use jsonrpc4j with Guava's immutable collections, but made a typo and jackson ObjectMapper wasn't configured. JsonRpcHttpClient correctly reads the response, but JsonMappingException is raised, caught as IOException. While handling incorrect error state another NPE is raised and original cause of the problem is lost.

I would like to have JsonRpcHttpClient.invoke() refacotred and the class tested properly, if no obligations are raised. Thanks