### PR TITLE
Possibility to explicitly define how to pass method parameters in JSON

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcMethod.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcMethod.java
@@ -18,4 +18,6 @@ public @interface JsonRpcMethod {
 	 */
 	String value();
 	
+	JsonRpcParamsPassMode paramsPassMode() default JsonRpcParamsPassMode.AUTO;
+	
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcParamsPassMode.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcParamsPassMode.java
@@ -1,0 +1,12 @@
+package com.googlecode.jsonrpc4j;
+
+/**
+ * The JSON-RPC specification allows either passing parameters as an Array, for by-position arguments, or as an Object,
+ * for by-name arguments.
+ *
+ */
+public enum JsonRpcParamsPassMode {
+	AUTO,
+	ARRAY,
+	OBJECT
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/ReflectionUtilTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/ReflectionUtilTest.java
@@ -43,6 +43,80 @@ public class ReflectionUtilTest {
 		assertEquals(2, namedParams.get("two"));
 	}
 	
+	@Test
+	public void noNamedParamsPassParamsAuto() throws Exception {
+		
+		Object[] arguments = {"1", 2};
+		assertSame(arguments, ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("noNamedParamsPassParamsAuto", String.class, int.class), arguments));
+	}
+	
+	@Test(expected = RuntimeException.class)
+	public void someNamedParamsPassParamsAuto() throws Exception {
+		
+		ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("someNamedParamsPassParamsAuto", String.class, int.class), null);
+	}
+	
+	@Test
+	public void allNamedParamsPassParamsAuto() throws Exception {
+		
+		Object[] arguments = {"1", 2};
+		@SuppressWarnings("unchecked")
+		Map<String, Object> namedParams = (Map<String, Object>) ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("allNamedParamsPassParamsAuto", String.class, int.class), arguments);
+		
+		assertEquals(2, namedParams.size());
+		assertEquals("1", namedParams.get("one"));
+		assertEquals(2, namedParams.get("two"));
+	}
+	
+	@Test
+	public void noNamedParamsPassParamsArray() throws Exception {
+		
+		Object[] arguments = {"1", 2};
+		assertSame(arguments, ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("noNamedParamsPassParamsArray", String.class, int.class), arguments));
+	}
+	
+	@Test(expected = RuntimeException.class)
+	public void someNamedParamsPassParamsArray() throws Exception {
+		
+		ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("someNamedParamsPassParamsArray", String.class, int.class), null);
+	}
+	
+	@Test
+	public void allNamedParamsPassParamsArray() throws Exception {
+		
+		Object[] arguments = {"1", 2};
+		Object[] params = (Object[]) ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("allNamedParamsPassParamsArray", String.class, int.class), arguments);
+		
+		assertEquals(2, params.length);
+		assertEquals("1", params[0]);
+		assertEquals(2, params[1]);
+	}
+	
+	@Test(expected = RuntimeException.class)
+	public void noNamedParamsPassParamsObject() throws Exception {
+		
+		Object[] arguments = {"1", 2};
+		ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("noNamedParamsPassParamsObject", String.class, int.class), arguments);
+	}
+	
+	@Test(expected = RuntimeException.class)
+	public void someNamedParamsPassParamsObject() throws Exception {
+		
+		ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("someNamedParamsPassParamsObject", String.class, int.class), null);
+	}
+	
+	@Test
+	public void allNamedParamsPassParamsObject() throws Exception {
+		
+		Object[] arguments = {"1", 2};
+		@SuppressWarnings("unchecked")
+		Map<String, Object> namedParams = (Map<String, Object>) ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("allNamedParamsPassParamsAuto", String.class, int.class), arguments);
+		
+		assertEquals(2, namedParams.size());
+		assertEquals("1", namedParams.get("one"));
+		assertEquals(2, namedParams.get("two"));
+	}
+	
 	private interface JsonRpcTestService {
 		
 		void noParams();
@@ -52,5 +126,32 @@ public class ReflectionUtilTest {
 		void someNamedParams(@JsonRpcParam("one") String one, int two);
 		
 		void allNamedParams(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
+		@JsonRpcMethod(value = "noNamedParamsPassParamsAuto", paramsPassMode = JsonRpcParamsPassMode.AUTO)
+		void noNamedParamsPassParamsAuto(String one, int two);
+
+		@JsonRpcMethod(value = "someNamedParamsPassParamsAuto", paramsPassMode = JsonRpcParamsPassMode.AUTO)
+		void someNamedParamsPassParamsAuto(@JsonRpcParam("one") String one, int two);
+
+		@JsonRpcMethod(value = "allNamedParamsPassParamsAuto", paramsPassMode = JsonRpcParamsPassMode.AUTO)
+		void allNamedParamsPassParamsAuto(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
+		@JsonRpcMethod(value = "noNamedParamsPassParamsArray", paramsPassMode = JsonRpcParamsPassMode.ARRAY)
+		void noNamedParamsPassParamsArray(String one, int two);
+
+		@JsonRpcMethod(value = "someNamedParamsPassParamsArray", paramsPassMode = JsonRpcParamsPassMode.ARRAY)
+		void someNamedParamsPassParamsArray(@JsonRpcParam("one") String one, int two);
+
+		@JsonRpcMethod(value = "allNamedParamsPassParamsArray", paramsPassMode = JsonRpcParamsPassMode.ARRAY)
+		void allNamedParamsPassParamsArray(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
+		@JsonRpcMethod(value = "noNamedParamsPassParamsObject", paramsPassMode = JsonRpcParamsPassMode.OBJECT)
+		void noNamedParamsPassParamsObject(String one, int two);
+
+		@JsonRpcMethod(value = "someNamedParamsPassParamsObject", paramsPassMode = JsonRpcParamsPassMode.OBJECT)
+		void someNamedParamsPassParamsObject(@JsonRpcParam("one") String one, int two);
+
+		@JsonRpcMethod(value = "allNamedParamsPassParamsObject", paramsPassMode = JsonRpcParamsPassMode.OBJECT)
+		void allNamedParamsPassParamsObject(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
 	}
 }


### PR DESCRIPTION
The JSON-RPC specification allows either passing parameters as an Array,
for by-position arguments, or as an Object, for by-name arguments.