### PR TITLE
JsonRpcMethod may be used to require a match on annotation value for rpc request

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project aims to provide the facility to easily implement
 JSON-RPC for the java programming language.  jsonrpc4j uses the
 [Jackson][Jackson page] library to convert java
 objects to and from json objects (and other things related to
-JSON-RPC). 
+JSON-RPC).
 
 [![Javadoc](https://img.shields.io/badge/javadoc-OK-blue.svg)](http://briandilley.github.io/jsonrpc4j/javadoc/1.5.0/)
 [ ![Download](https://api.bintray.com/packages/gaborbernat/maven/com.github.briandilley.jsonrpc4j%3Ajsonrpc4j/images/download.svg) ](https://bintray.com/gaborbernat/maven/com.github.briandilley.jsonrpc4j%3Ajsonrpc4j/_latestVersion)
@@ -373,6 +373,8 @@ Of course, this is all possible in the Spring Framework as well:
         </property>
     </bean>
 ```
+	}
+
 
 ### `JsonRpcServer` settings explained
 The following settings apply to both the `JsonRpcServer` and `JsonServiceExporter`:
@@ -387,12 +389,13 @@ The following settings apply to both the `JsonRpcServer` and `JsonServiceExporte
 Methods are resolved in the following way, each step immediately short circuits the
 process when the available methods is 1 or less.
 
-  1. All methods with the same name as the request method are considered
-  2. If `allowLessParams` is disabled methods with more parameters than the request are removed
-  3. If `allowExtraParams` is disabled then methods with less parameters than the request are removed
-  4. If either of the two parameters above are enabled then methods with the lowest difference in parameter count from the request are kept
-  5. Parameters types are compared to the request parameters and the method(s) with the highest number of matching parameters is kept
-  6. If there are multiple methods remaining then the first of them are used
+  1. If a method has the @JsonRpcMethod annotation, then if the annotation value has the same name as the request method, it is considered.  If the annotation has `required` set to `true`, then the Java method name is not considered.
+  1. Otherwise, all methods with the same name as the request method are considered.
+  1. If `allowLessParams` is disabled methods with more parameters than the request are removed
+  1. If `allowExtraParams` is disabled then methods with less parameters than the request are removed
+  1. If either of the two parameters above are enabled then methods with the lowest difference in parameter count from the request are kept
+  1. Parameters types are compared to the request parameters and the method(s) with the highest number of matching parameters is kept
+  1. If there are multiple methods remaining then the first of them are used
 
 jsonrpc4j's method resolution allows for overloaded methods _sometimes_.  Primitives are
 easily resolved from json to java.  But resolution between other objects are not possible.
@@ -436,7 +439,8 @@ and `UserObjectEx` Plain Old Java Objects.
 #### Custom method names
 
 In some instances, you may need to expose a JsonRpc method that is not a valid Java method name.
-In this case, use the annotation @JsonRpcMethod on the service method.
+In this case, use the annotation @JsonRpcMethod on the service method.  You may also use this annotation
+to disambiguate overloaded methods by setting the `required` property on the annotation to `true`.
 
 ```java
 @JsonRpcService("/jsonrpc")

--- a/README.md
+++ b/README.md
@@ -390,12 +390,12 @@ Methods are resolved in the following way, each step immediately short circuits 
 process when the available methods is 1 or less.
 
   1. If a method has the @JsonRpcMethod annotation, then if the annotation value has the same name as the request method, it is considered.  If the annotation has `required` set to `true`, then the Java method name is not considered.
-  1. Otherwise, all methods with the same name as the request method are considered.
-  1. If `allowLessParams` is disabled methods with more parameters than the request are removed
-  1. If `allowExtraParams` is disabled then methods with less parameters than the request are removed
-  1. If either of the two parameters above are enabled then methods with the lowest difference in parameter count from the request are kept
-  1. Parameters types are compared to the request parameters and the method(s) with the highest number of matching parameters is kept
-  1. If there are multiple methods remaining then the first of them are used
+  2. Otherwise, all methods with the same name as the request method are considered.
+  3. If `allowLessParams` is disabled methods with more parameters than the request are removed
+  4. If `allowExtraParams` is disabled then methods with less parameters than the request are removed
+  5. If either of the two parameters above are enabled then methods with the lowest difference in parameter count from the request are kept
+  6. Parameters types are compared to the request parameters and the method(s) with the highest number of matching parameters is kept
+  7. If there are multiple methods remaining then the first of them are used
 
 jsonrpc4j's method resolution allows for overloaded methods _sometimes_.  Primitives are
 easily resolved from json to java.  But resolution between other objects are not possible.

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -86,6 +86,7 @@ public class JsonRpcBasicServer {
 	private boolean rethrowExceptions = false;
 	private boolean allowExtraParams = false;
 	private boolean allowLessParams = false;
+	private boolean requireAnnotatedMethodName = false;
 	private RequestInterceptor requestInterceptor = null;
 	private ErrorResolver errorResolver = null;
 	private InvocationListener invocationListener = null;
@@ -345,7 +346,7 @@ public class JsonRpcBasicServer {
 		final String partialMethodName = getMethodName(fullMethodName);
 		final String serviceName = getServiceName(fullMethodName);
 		
-		Set<Method> methods = findCandidateMethods(getHandlerInterfaces(serviceName), partialMethodName);
+		Set<Method> methods = findCandidateMethods(getHandlerInterfaces(serviceName), partialMethodName, requireAnnotatedMethodName);
 		if (methods.isEmpty())
 			return writeAndFlushValueError(output, createResponseError(jsonRpc, id, JsonError.METHOD_NOT_FOUND));
 		AMethodWithItsArgs methodArgs = findBestMethodByParamsNode(methods, node.get(PARAMS));
@@ -910,6 +911,17 @@ public class JsonRpcBasicServer {
 	public void setAllowLessParams(boolean allowLessParams) {
 		this.allowLessParams = allowLessParams;
 	}
+
+  /**
+   * Sets whether or not the server should require method name specified in the JsonRpcMethod annotation
+   * if it is present.  When true, JsonRpcMethod annotations can be used to resolve ambiguity between
+   * overloaded methods that take the same number of Object type parameters.
+   *
+   * @param requireAnnotatedMethodName the requireAnnotatedMethodName to set
+   */
+  public void setRequireAnnotatedMethodName(boolean requireAnnotatedMethodName) {
+    this.requireAnnotatedMethodName = requireAnnotatedMethodName;
+  }
 	
 	/**
 	 * Sets the {@link ErrorResolver} used for resolving errors.

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -86,7 +86,6 @@ public class JsonRpcBasicServer {
 	private boolean rethrowExceptions = false;
 	private boolean allowExtraParams = false;
 	private boolean allowLessParams = false;
-	private boolean requireAnnotatedMethodName = false;
 	private RequestInterceptor requestInterceptor = null;
 	private ErrorResolver errorResolver = null;
 	private InvocationListener invocationListener = null;
@@ -346,7 +345,7 @@ public class JsonRpcBasicServer {
 		final String partialMethodName = getMethodName(fullMethodName);
 		final String serviceName = getServiceName(fullMethodName);
 		
-		Set<Method> methods = findCandidateMethods(getHandlerInterfaces(serviceName), partialMethodName, requireAnnotatedMethodName);
+		Set<Method> methods = findCandidateMethods(getHandlerInterfaces(serviceName), partialMethodName);
 		if (methods.isEmpty())
 			return writeAndFlushValueError(output, createResponseError(jsonRpc, id, JsonError.METHOD_NOT_FOUND));
 		AMethodWithItsArgs methodArgs = findBestMethodByParamsNode(methods, node.get(PARAMS));
@@ -912,17 +911,6 @@ public class JsonRpcBasicServer {
 		this.allowLessParams = allowLessParams;
 	}
 
-  /**
-   * Sets whether or not the server should require method name specified in the JsonRpcMethod annotation
-   * if it is present.  When true, JsonRpcMethod annotations can be used to resolve ambiguity between
-   * overloaded methods that take the same number of Object type parameters.
-   *
-   * @param requireAnnotatedMethodName the requireAnnotatedMethodName to set
-   */
-  public void setRequireAnnotatedMethodName(boolean requireAnnotatedMethodName) {
-    this.requireAnnotatedMethodName = requireAnnotatedMethodName;
-  }
-	
 	/**
 	 * Sets the {@link ErrorResolver} used for resolving errors.
 	 * Multiple {@link ErrorResolver}s can be used at once by

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcMethod.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcMethod.java
@@ -20,4 +20,9 @@ public @interface JsonRpcMethod {
 	
 	JsonRpcParamsPassMode paramsPassMode() default JsonRpcParamsPassMode.AUTO;
 	
+  /**
+   * If {@code true}, the Java method name will not be used to resolve rpc calls.
+   * @return whether the {@link #value()} is required to match the method.
+   */
+  boolean required() default false;
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/ReflectionUtil.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/ReflectionUtil.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Utilities for reflection.
  */
-@SuppressWarnings("unused")
 public abstract class ReflectionUtil {
 	
 	private static final Map<String, Set<Method>> methodCache = new ConcurrentHashMap<>();
@@ -29,11 +28,13 @@ public abstract class ReflectionUtil {
 	/**
 	 * Finds methods with the given name on the given class.
 	 *
-	 * @param classes the classes
-	 * @param name    the method name
+	 * @param classes                    the classes
+	 * @param name                       the method name
+	 * @param requireAnnotatedMethodName if true, and the JsonRpcMethod annotation is present on a class its value must match
+	 *                                   to be a candidate.
 	 * @return the methods
 	 */
-	static Set<Method> findCandidateMethods(Class<?>[] classes, String name) {
+	static Set<Method> findCandidateMethods(Class<?>[] classes, String name, boolean requireAnnotatedMethodName) {
 		StringBuilder sb = new StringBuilder();
 		for (Class<?> clazz : classes) {
 			sb.append(clazz.getName()).append("::");
@@ -45,8 +46,9 @@ public abstract class ReflectionUtil {
 		Set<Method> methods = new HashSet<>();
 		for (Class<?> clazz : classes) {
 			for (Method method : clazz.getMethods()) {
-				if (method.getName().equals(name) || annotationMatches(method, name)) {
-					methods.add(method);
+				if (method.getName().equals(name) && (!requireAnnotatedMethodName || !method.isAnnotationPresent(JsonRpcMethod.class)) ||
+				    annotationMatches(method, name)) {
+          methods.add(method);
 				}
 			}
 		}

--- a/src/test/java/com/googlecode/jsonrpc4j/ReflectionUtilTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/ReflectionUtilTest.java
@@ -121,9 +121,9 @@ public class ReflectionUtilTest {
 	
   @Test
   public void sameNameObjectParamJsonRpcMethod() {
-    Set<Method> methods = ReflectionUtil.findCandidateMethods(new Class<?>[] { JsonRpcTestService.class }, "objectParamSameName", true);
+    Set<Method> methods = ReflectionUtil.findCandidateMethods(new Class<?>[] { JsonRpcTestService.class }, "objectParamSameName");
     assertEquals(1, methods.size());
-    methods = ReflectionUtil.findCandidateMethods(new Class<?>[] { JsonRpcTestService.class }, "diffMethodName", true);
+    methods = ReflectionUtil.findCandidateMethods(new Class<?>[] { JsonRpcTestService.class }, "diffMethodName");
     assertEquals(1, methods.size());
   }
 
@@ -166,7 +166,7 @@ public class ReflectionUtilTest {
 
     void objectParamSameName(Object1 obj);
 
-    @JsonRpcMethod("diffMethodName")
+    @JsonRpcMethod(value="diffMethodName", required=true)
     void objectParamSameName(Object2 obj);
 	}
 

--- a/src/test/java/com/googlecode/jsonrpc4j/ReflectionUtilTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/ReflectionUtilTest.java
@@ -1,11 +1,13 @@
 package com.googlecode.jsonrpc4j;
 
-import org.junit.Test;
-
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
 
 public class ReflectionUtilTest {
 	
@@ -117,6 +119,14 @@ public class ReflectionUtilTest {
 		assertEquals(2, namedParams.get("two"));
 	}
 	
+  @Test
+  public void sameNameObjectParamJsonRpcMethod() {
+    Set<Method> methods = ReflectionUtil.findCandidateMethods(new Class<?>[] { JsonRpcTestService.class }, "objectParamSameName", true);
+    assertEquals(1, methods.size());
+    methods = ReflectionUtil.findCandidateMethods(new Class<?>[] { JsonRpcTestService.class }, "diffMethodName", true);
+    assertEquals(1, methods.size());
+  }
+
 	private interface JsonRpcTestService {
 		
 		void noParams();
@@ -153,5 +163,36 @@ public class ReflectionUtilTest {
 
 		@JsonRpcMethod(value = "allNamedParamsPassParamsObject", paramsPassMode = JsonRpcParamsPassMode.OBJECT)
 		void allNamedParamsPassParamsObject(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
+    void objectParamSameName(Object1 obj);
+
+    @JsonRpcMethod("diffMethodName")
+    void objectParamSameName(Object2 obj);
 	}
+
+  private static class Object1 {
+    String foo;
+
+    public String getFoo() {
+      return foo;
+    }
+
+    public void setFoo(String foo) {
+      this.foo = foo;
+    }
+  }
+
+  private static class Object2 {
+    String foo;
+
+    public String getFoo() {
+      return foo;
+    }
+
+    public void setFoo(String foo) {
+      this.foo = foo;
+    }
+
+  }
+
 }


### PR DESCRIPTION
For issue #179 

These changes allow disambiguation of rpc method requests when the exposed API has overloaded methods.  The JsonRpcMethod annotation has a new flag that when true matches only against the annotation value for rpc methods instead of the annotation or the java method name.  The default is false so that the current behavior is unchanged.  

I struggled a bit with the boolean logic in `findCandidateMethods`.  I finally settled on something that is more verbose but the boolean conditions are clearer.  Other variations that were more compact were also more confusing IMO, leading to harder to maintain code.