### PR TITLE
parse long ids on requests as longs instead of int

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -860,8 +860,9 @@ public class JsonRpcBasicServer {
 		if (node.isDouble()) return node.asDouble();
 		if (node.isFloatingPointNumber()) return node.asDouble();
 		if (node.isInt()) return node.asInt();
-		if (node.isIntegralNumber()) return node.asInt();
 		if (node.isLong()) return node.asLong();
+		//TODO(donequis): consider parsing bigints
+		if (node.isIntegralNumber()) return node.asInt();
 		if (node.isTextual()) return node.asText();
 		throw new IllegalArgumentException("Unknown id type");
 	}

--- a/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcBasicServerTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcBasicServerTest.java
@@ -27,6 +27,7 @@ import static com.googlecode.jsonrpc4j.util.Util.decodeAnswer;
 import static com.googlecode.jsonrpc4j.util.Util.getFromArrayWithId;
 import static com.googlecode.jsonrpc4j.util.Util.intParam1;
 import static com.googlecode.jsonrpc4j.util.Util.intParam2;
+import static com.googlecode.jsonrpc4j.util.Util.longParam;
 import static com.googlecode.jsonrpc4j.util.Util.messageOfStream;
 import static com.googlecode.jsonrpc4j.util.Util.messageWithListParams;
 import static com.googlecode.jsonrpc4j.util.Util.messageWithListParamsStream;
@@ -184,7 +185,15 @@ public class JsonRpcBasicServerTest {
 		jsonRpcServer.handleRequest(messageWithListParamsStream(intParam1, "testMethod", param1), byteArrayOutputStream);
 		assertTrue(decodeAnswer(byteArrayOutputStream).get(ID).isIntegralNumber());
 	}
-	
+
+	@Test
+	public void idLongType() throws Exception {
+		EasyMock.expect(mockService.testMethod(param1)).andReturn(param1);
+		EasyMock.replay(mockService);
+		jsonRpcServer.handleRequest(messageWithListParamsStream(longParam, "testMethod", param1), byteArrayOutputStream);
+		assertTrue(decodeAnswer(byteArrayOutputStream).get(ID).isLong());
+	}
+
 	@Test
 	public void idStringType() throws Exception {
 		EasyMock.expect(mockService.testMethod(param1)).andReturn(param1);

--- a/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
@@ -253,30 +253,4 @@ public class JsonRpcServerTest {
 		String testMethod(String param1);
 	}
 
-	@Test
-	public void testGetMethod_longId() throws Exception {
-		EasyMock.expect(mockService.testMethod("Whirinaki")).andReturn("Forest");
-		EasyMock.replay(mockService);
-
-		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test-get");
-		MockHttpServletResponse response = new MockHttpServletResponse();
-
-		request.addParameter("id", "1600000000000");
-		request.addParameter("method", "testMethod");
-		request.addParameter("params", "{}");
-
-		jsonRpcServer.handle(request, response);
-		String contentResponse = response.getContentAsString();
-		String[] results = contentResponse.split(",");
-		String idstr = null;
-		for (String s : results) {
-			if (s.contains("\"id\"")) {
-				idstr = s;
-				break;
-			}
-		}
-		Long resid = Long.valueOf(idstr.split(":")[1]);
-		Assert.assertTrue(resid == 1600000000000L);
-	}
-
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcServerTest.java
@@ -252,5 +252,31 @@ public class JsonRpcServerTest {
 	public interface ServiceInterface {
 		String testMethod(String param1);
 	}
-	
+
+	@Test
+	public void testGetMethod_longId() throws Exception {
+		EasyMock.expect(mockService.testMethod("Whirinaki")).andReturn("Forest");
+		EasyMock.replay(mockService);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test-get");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		request.addParameter("id", "1600000000000");
+		request.addParameter("method", "testMethod");
+		request.addParameter("params", "{}");
+
+		jsonRpcServer.handle(request, response);
+		String contentResponse = response.getContentAsString();
+		String[] results = contentResponse.split(",");
+		String idstr = null;
+		for (String s : results) {
+			if (s.contains("\"id\"")) {
+				idstr = s;
+				break;
+			}
+		}
+		Long resid = Long.valueOf(idstr.split(":")[1]);
+		Assert.assertTrue(resid == 1600000000000L);
+	}
+
 }

--- a/src/test/java/com/googlecode/jsonrpc4j/util/Util.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/Util.java
@@ -23,6 +23,7 @@ public class Util {
 	public static final String param4 = "param4";
 	public static final int intParam1 = 1;
 	public static final int intParam2 = 2;
+	public static final long longParam = 1600000000000L;
 	public static final String JSON_ENCODING = StandardCharsets.UTF_8.name();
 	public static final ObjectMapper mapper = new ObjectMapper();
 	@SuppressWarnings("PMD.AvoidUsingHardCodedIP")


### PR DESCRIPTION
if an id is an integer bigger than MAX_INT or similar, it will overflow
this change allows parsing Long values, though not arbitrary large integers

The test here is ugly, you can check https://github.com/briandilley/jsonrpc4j/pull/185 for a better approach