### PR TITLE
Fixes for issue #171

### DIFF
--- a/src/test/java/com/googlecode/jsonrpc4j/integration/HttpCodeTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/integration/HttpCodeTest.java
@@ -1,10 +1,15 @@
 package com.googlecode.jsonrpc4j.integration;
 
+import com.googlecode.jsonrpc4j.JsonRpcClientException;
 import com.googlecode.jsonrpc4j.ProxyUtil;
+import com.googlecode.jsonrpc4j.spring.rest.JsonRpcRestClient;
 import com.googlecode.jsonrpc4j.util.BaseRestTest;
 import com.googlecode.jsonrpc4j.util.FakeServiceInterface;
 import com.googlecode.jsonrpc4j.util.FakeServiceInterfaceImpl;
+import com.googlecode.jsonrpc4j.util.JettyServer;
 import org.junit.Test;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
 
 import java.net.MalformedURLException;
 
@@ -32,6 +37,22 @@ public class HttpCodeTest extends BaseRestTest {
 		service.doSomething();
 	}
 	
+	@Test
+	public void httpCustomStatus() throws MalformedURLException {
+		expectedEx.expectMessage(equalTo("Server Error"));
+		expectedEx.expect(JsonRpcClientException.class);
+
+		RestTemplate restTemplate = new RestTemplate();
+
+		JsonRpcRestClient client = getClient(JettyServer.SERVLET, restTemplate);
+
+		// Overwrite error handler for error check.
+		restTemplate.setErrorHandler(new DefaultResponseErrorHandler());
+
+		FakeServiceInterface service = ProxyUtil.createClientProxy(FakeServiceInterface.class, client);
+		service.throwSomeException("function error");
+	}
+
 	@Override
 	protected Class service() {
 		return FakeServiceInterfaceImpl.class;

--- a/src/test/java/com/googlecode/jsonrpc4j/util/BaseRestTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/BaseRestTest.java
@@ -7,6 +7,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
+import org.springframework.web.client.RestTemplate;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -42,6 +43,10 @@ public abstract class BaseRestTest {
 		return new JsonRpcRestClient(new URL(jettyServer.getCustomServerUrlString(servlet)));
 	}
 	
+	protected JsonRpcRestClient getClient(final String servlet, RestTemplate restTemplate) throws MalformedURLException {
+		return new JsonRpcRestClient(new URL(jettyServer.getCustomServerUrlString(servlet)), restTemplate);
+	}
+
 	protected JsonRpcHttpClient getHttpClient(boolean gzipRequests, boolean acceptGzipResponses) throws MalformedURLException {
 		Map<String, String> header = new HashMap<>();
 		return new JsonRpcHttpClient(new ObjectMapper(), new URL(jettyServer.getCustomServerUrlString(JettyServer.SERVLET)), header, gzipRequests, acceptGzipResponses);


### PR DESCRIPTION
Status is set before ContentLength.
This will return HTTP error code generated by an HttpStatusCodeProvider.