### PR TITLE
Remove build-announcements plugin, it is no longer compatible with ...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'findbugs'
     id 'pmd'
     id 'jacoco'
-    id 'build-announcements'
     id 'nebula.info' version '3.4.1'
     id 'com.github.ben-manes.versions' version '0.13.0'
     id 'osgi'


### PR DESCRIPTION
MacOS X Sierra/High Sierra