### PR TITLE
Handle empty line requests as parse errors

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -241,7 +241,7 @@ public class JsonRpcBasicServer {
 				interceptor.preHandleJson(jsonNode);
 			}
 			return handleJsonNodeRequest(jsonNode, output).code;
-		} catch (JsonParseException e) {
+		} catch (JsonParseException | JsonMappingException e) {
 			return writeAndFlushValueError(output, createResponseError(VERSION, NULL, JsonError.PARSE_ERROR)).code;
 		}
 	}

--- a/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcBasicServerTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/server/JsonRpcBasicServerTest.java
@@ -2,6 +2,7 @@ package com.googlecode.jsonrpc4j.server;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.googlecode.jsonrpc4j.ConvertedParameterTransformer;
+import com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
 import com.googlecode.jsonrpc4j.InvocationListener;
 import com.googlecode.jsonrpc4j.JsonRpcBasicServer;
 import com.googlecode.jsonrpc4j.JsonRpcInterceptor;
@@ -201,7 +202,19 @@ public class JsonRpcBasicServerTest {
 		assertTrue(byteArrayOutputStream.toString(Util.JSON_ENCODING).isEmpty());
 		assertEquals(ok_code, JsonRpcBasicServer.CODE_OK);
 	}
-	
+
+	@Test
+	public void receiveInvalidJson() throws IOException {
+		jsonRpcServer.handleRequest(invalidJsonStream(), byteArrayOutputStream);
+		assertEquals(JsonError.PARSE_ERROR.code, decodeAnswer(byteArrayOutputStream).get(JsonRpcBasicServer.ERROR).get(JsonRpcBasicServer.ERROR_CODE).intValue());
+	}
+
+	@Test
+	public void receiveEmptyLine() throws IOException {
+		jsonRpcServer.handleRequest(emptyLineStream(), byteArrayOutputStream);
+		assertEquals(JsonError.PARSE_ERROR.code, decodeAnswer(byteArrayOutputStream).get(JsonRpcBasicServer.ERROR).get(JsonRpcBasicServer.ERROR_CODE).intValue());
+	}
+
 	/**
 	 * The {@link com.googlecode.jsonrpc4j.JsonRpcBasicServer} is able to have an instance of
 	 * {@link com.googlecode.jsonrpc4j.InvocationListener} configured for it.  Prior to a

--- a/src/test/java/com/googlecode/jsonrpc4j/util/Util.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/util/Util.java
@@ -35,6 +35,7 @@ public class Util {
 			" \"id\": \n" +
 			" }\n" +
 			" ";
+	private static final String emptyLine = "\n";
 	
 	public static InputStream invalidJsonRpcRequestStream() {
 		return new ByteArrayInputStream(invalidJsonRpcRequest.getBytes(StandardCharsets.UTF_8));
@@ -42,6 +43,10 @@ public class Util {
 	
 	public static InputStream invalidJsonStream() {
 		return new ByteArrayInputStream(invalidJson.getBytes(StandardCharsets.UTF_8));
+	}
+
+	public static InputStream emptyLineStream() {
+		return new ByteArrayInputStream(emptyLine.getBytes(StandardCharsets.UTF_8));
 	}
 	
 	public static InputStream messageWithListParamsStream(final Object id, final String methodName, final Object... args) throws JsonProcessingException {


### PR DESCRIPTION
There is an edge case where a request consisting of just a single newline character (`"\n"`, an empty line) would cause `JsonRpcBasicServer::handleRequest()` to throw a `JsonMappingException` and not write any response to the output stream.

I think that it makes more sense to treat this as a client error and respond with a _parse error_ (-32700) instead of throwing.

This PR contains both a test describing the expected behavior and a fix to implement it.