### PR TITLE
Send PARSE_ERROR response error for malformed method arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 description = 'This project aims to provide the facility to easily implement JSON-RPC for the java programming language.'
-version = '1.5.3'
+version = '1.5.3-2'
 group = 'com.github.briandilley.jsonrpc4j'
 
 sourceCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
         jacksonVersion = '2.10.2'
         springVersion = '4.3.26.RELEASE'
         springBotVersion = '1.4.7.RELEASE'
-        jettyVersion = '9.4.26.v20200117'
+        jettyVersion = '9.4.0.RC3'
         slf4jVersion = '1.7.30'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,10 @@ compileTestJava {
     options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 }
 
+apply plugin: "maven"
+
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,11 @@ repositories {
 
 dependencies {
     ext {
-        jacksonVersion = '2.8.5'
-        springVersion = '4.3.5.RELEASE'
-        springBotVersion = '1.4.3.RELEASE'
-        jettyVersion = '9.4.0.RC3'
-        slf4jVersion = '1.7.22'
+        jacksonVersion = '2.10.2'
+        springVersion = '4.3.26.RELEASE'
+        springBotVersion = '1.4.7.RELEASE'
+        jettyVersion = '9.4.26.v20200117'
+        slf4jVersion = '1.7.30'
     }
 
     compile 'net.iharder:base64:2.3.9'

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -373,7 +373,6 @@ public class JsonRpcBasicServer {
 			} catch (JsonParseException | JsonMappingException e) {
 				throw e; // rethrow this, it will be handled as PARSE_ERROR later
 			} catch (Throwable e) {
-				System.out.println("Co to je?????????????,");
 				handler.error = e;
 				return handleError(output, id, jsonRpc, methodArgs, e);
 			}

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -370,7 +370,10 @@ public class JsonRpcBasicServer {
 					writeAndFlushValue(output, response);
 				}
 				return JsonError.OK;
+			} catch (JsonParseException | JsonMappingException e) {
+				throw e; // rethrow this, it will be handled as PARSE_ERROR later
 			} catch (Throwable e) {
+				System.out.println("Co to je?????????????,");
 				handler.error = e;
 				return handleError(output, id, jsonRpc, methodArgs, e);
 			}


### PR DESCRIPTION
Fix sending JsonMappingException and JsonParseException as response for reading errors in method arguments.

Now a PARSE_ERROR response error is send instead as in case of call body malformation.