### PR TITLE
Modify JsonRpcServer constructor access to public

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -77,7 +77,7 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 	 * @param handler         the {@code handler}
 	 * @param remoteInterface the interface
 	 */
-	private JsonRpcServer(Object handler, Class<?> remoteInterface) {
+	public JsonRpcServer(Object handler, Class<?> remoteInterface) {
 		super(new ObjectMapper(), handler, remoteInterface);
 		this.gzipResponses = false;
 	}


### PR DESCRIPTION
The JsonRpcServer constructor (private JsonRpcServer(Object handler, Class<?> remoteInterface)) should be public.

For example: new JsonRpcServer(new HelloWorldServiceImpl(), HelloWorldService.class);