### PR TITLE
uplift jackson to 2.9.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     ext {
-        jacksonVersion = '2.8.5'
+        jacksonVersion = '2.9.8'
         springVersion = '4.3.5.RELEASE'
         springBotVersion = '1.4.3.RELEASE'
         jettyVersion = '9.4.0.RC3'


### PR DESCRIPTION
quite old version of jackson is used.
In our project this will downlift our version, not a big deal because we can exclude it from this library but would be nice to not have to