### PR TITLE
fix #251

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -325,7 +325,7 @@ public class JsonRpcClient {
 	}
 	
 	protected boolean hasError(ObjectNode jsonObject) {
-		return jsonObject.has(ERROR) && jsonObject.get(ERROR) != null && !jsonObject.get(ERROR).isNull();
+		return jsonObject.has(ERROR) && jsonObject.get(ERROR) != null && !jsonObject.get(ERROR).isNull() && !(jsonObject.get(ERROR).isInt() && jsonObject.intValue()==0) ;
 	}
 	
 	/**

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcClient.java
@@ -343,6 +343,7 @@ public class JsonRpcClient {
 		addParameters(arguments, request);
 		addAdditionalHeaders(request);
 		notifyBeforeRequestListener(request);
+		addNoneArguments(request);
 		return request;
 	}
 	
@@ -421,6 +422,13 @@ public class JsonRpcClient {
 	
 	private boolean isCollectionArguments(Object arguments) {
 		return arguments != null && Collection.class.isInstance(arguments);
+	}
+	
+	private void addNoneArguments(ObjectNode request){
+		if (!request.has(PARAMS)){
+			//for none params add an empty array
+			request.set(PARAMS,mapper.valueToTree(new String[0]));
+		}
 	}
 	
 	private void addCollectionArguments(Object arguments, ObjectNode request) {


### PR DESCRIPTION
fix the issue 
https://github.com/briandilley/jsonrpc4j/issues/251
add params node into request when args is null or empty .

some jsonrpc server need check the struct of request. it's need params node athough this node may empty or null;