### PR TITLE
added support for fixed parameters via annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,54 @@ public interface LibraryService {
 ```json
 {"jsonrpc":"2.0", "method": "VideoLibrary.GetTVShows", "params": { "properties": ["title"] }, "id":1}
 ```
+#### Fixed parameters
+
+You may need to pass some fixed parameters to a JsonRpc method. In this case, use the annotation @JsonRpcFixedParam on the service method.  You may also use @JsonRpcFixedParams to pass a collection of fixed parameters.
+
+```java
+@JsonRpcService("/jsonrpc")
+public interface LibraryService {
+    @JsonRpcMethod("VideoLibrary.GetTVShows")
+    @JsonRpcFixedParam(name = "status", value = "published")
+    List<TVShow> fetchTVShows(@JsonRpcParam(value="properties") final List<String> properties);
+}
+```
+
+```json
+{
+    "jsonrpc":"2.0", 
+    "method": "VideoLibrary.GetTVShows", 
+    "params": { 
+        "status": "published", 
+        "properties": ["title"] 
+    }, 
+    "id":1
+}
+```
+
+```java
+@JsonRpcService("/jsonrpc")
+public interface LibraryService {
+    @JsonRpcMethod("VideoLibrary.GetTVShows")
+    @JsonRpcFixedParams(fixedParams = { 
+        @JsonRpcFixedParam(name = "status", value = "published"), 
+        @JsonRpcFixedParam(name = "order_by", value = "recent") })
+    List<TVShow> fetchTVShows(@JsonRpcParam(value="properties") final List<String> properties);
+}
+```
+
+```json
+{
+    "jsonrpc":"2.0", 
+    "method": "VideoLibrary.GetTVShows", 
+    "params": { 
+        "status": "published", 
+        "order_by": "recent", 
+        "properties": ["title"] 
+    }, 
+    "id":1
+}
+```
 
 [Google Group]: http://groups.google.com/group/json-rpc
 [Jackson page]: https://github.com/FasterXML/jackson

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcFixedParam.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcFixedParam.java
@@ -1,0 +1,21 @@
+package com.googlecode.jsonrpc4j;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonRpcFixedParam {
+
+    /**
+     * @return the parameter's name.
+     */
+    String name();
+
+    /**
+     * @return the parameter's value.
+     */
+    String value();
+}

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcFixedParams.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcFixedParams.java
@@ -1,0 +1,16 @@
+package com.googlecode.jsonrpc4j;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonRpcFixedParams {
+
+    /**
+     * @return a fixed parameter's collection.
+     */
+    JsonRpcFixedParam[] fixedParams();
+}

--- a/src/test/java/com/googlecode/jsonrpc4j/ReflectionUtilTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/ReflectionUtilTest.java
@@ -57,6 +57,35 @@ public class ReflectionUtilTest {
 		
 		ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("someNamedParamsPassParamsAuto", String.class, int.class), null);
 	}
+
+	@Test
+	public void fixedParamPassParamsAuto() throws Exception {
+		Object[] arguments = { "1", 2 };
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> params = (Map<String, Object>) ReflectionUtil.parseArguments(
+				JsonRpcTestService.class.getMethod("fixedParamPassParamsAuto", String.class, int.class), arguments);
+
+		assertEquals(3, params.size());
+		assertEquals("1", params.get("one"));
+		assertEquals(2, params.get("two"));
+		assertEquals("value1", params.get("param1"));
+	}
+
+	@Test
+	public void fixedParamsPassParamsAuto() throws Exception {
+		Object[] arguments = { "1", 2 };
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> params = (Map<String, Object>) ReflectionUtil.parseArguments(
+				JsonRpcTestService.class.getMethod("fixedParamsPassParamsAuto", String.class, int.class), arguments);
+
+		assertEquals(4, params.size());
+		assertEquals("1", params.get("one"));
+		assertEquals(2, params.get("two"));
+		assertEquals("value1", params.get("param1"));
+		assertEquals("value2", params.get("param2"));
+	}
 	
 	@Test
 	public void allNamedParamsPassParamsAuto() throws Exception {
@@ -82,6 +111,33 @@ public class ReflectionUtilTest {
 		
 		ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("someNamedParamsPassParamsArray", String.class, int.class), null);
 	}
+
+	@Test
+	public void fixedParamPassParamsArray() throws Exception {
+		Object[] arguments = { "1", 2 };
+		
+		Object[] params = (Object[]) ReflectionUtil.parseArguments(
+				JsonRpcTestService.class.getMethod("fixedParamPassParamsArray", String.class, int.class), arguments);
+
+		assertEquals(3, params.length);
+		assertEquals("value1", params[0]);
+		assertEquals("1", params[1]);
+		assertEquals(2, params[2]);
+	}
+
+	@Test
+	public void fixedParamsPassParamsArray() throws Exception {
+		Object[] arguments = { "1", 2 };
+
+		Object[] params = (Object[]) ReflectionUtil.parseArguments(
+				JsonRpcTestService.class.getMethod("fixedParamsPassParamsArray", String.class, int.class), arguments);
+
+		assertEquals(4, params.length);
+		assertEquals("value1", params[0]);
+		assertEquals("value2", params[1]);
+		assertEquals("1", params[2]);
+		assertEquals(2, params[3]);
+	}
 	
 	@Test
 	public void allNamedParamsPassParamsArray() throws Exception {
@@ -105,6 +161,35 @@ public class ReflectionUtilTest {
 	public void someNamedParamsPassParamsObject() throws Exception {
 		
 		ReflectionUtil.parseArguments(JsonRpcTestService.class.getMethod("someNamedParamsPassParamsObject", String.class, int.class), null);
+	}
+
+	@Test
+	public void fixedParamPassParamsObject() throws Exception {
+		Object[] arguments = { "1", 2 };
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> params = (Map<String, Object>) ReflectionUtil.parseArguments(
+				JsonRpcTestService.class.getMethod("fixedParamPassParamsObject", String.class, int.class), arguments);
+
+		assertEquals(3, params.size());
+		assertEquals("1", params.get("one"));
+		assertEquals(2, params.get("two"));
+		assertEquals("value1", params.get("param1"));
+	}
+
+	@Test
+	public void fixedParamsPassParamsObject() throws Exception {
+		Object[] arguments = { "1", 2 };
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> params = (Map<String, Object>) ReflectionUtil.parseArguments(
+				JsonRpcTestService.class.getMethod("fixedParamsPassParamsObject", String.class, int.class), arguments);
+
+		assertEquals(4, params.size());
+		assertEquals("1", params.get("one"));
+		assertEquals(2, params.get("two"));
+		assertEquals("value1", params.get("param1"));
+		assertEquals("value2", params.get("param2"));
 	}
 	
 	@Test
@@ -143,6 +228,15 @@ public class ReflectionUtilTest {
 		@JsonRpcMethod(value = "someNamedParamsPassParamsAuto", paramsPassMode = JsonRpcParamsPassMode.AUTO)
 		void someNamedParamsPassParamsAuto(@JsonRpcParam("one") String one, int two);
 
+		@JsonRpcMethod(value = "fixedParamPassParamsAuto", paramsPassMode = JsonRpcParamsPassMode.AUTO)
+		@JsonRpcFixedParam(name = "param1", value = "value1")
+		void fixedParamPassParamsAuto(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
+		@JsonRpcMethod(value = "fixedParamsPassParamsAuto", paramsPassMode = JsonRpcParamsPassMode.AUTO)
+		@JsonRpcFixedParams(fixedParams = { @JsonRpcFixedParam(name = "param1", value = "value1"),
+				@JsonRpcFixedParam(name = "param2", value = "value2") })
+		void fixedParamsPassParamsAuto(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
 		@JsonRpcMethod(value = "allNamedParamsPassParamsAuto", paramsPassMode = JsonRpcParamsPassMode.AUTO)
 		void allNamedParamsPassParamsAuto(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
 
@@ -152,6 +246,15 @@ public class ReflectionUtilTest {
 		@JsonRpcMethod(value = "someNamedParamsPassParamsArray", paramsPassMode = JsonRpcParamsPassMode.ARRAY)
 		void someNamedParamsPassParamsArray(@JsonRpcParam("one") String one, int two);
 
+		@JsonRpcMethod(value = "fixedParamPassParamsArray", paramsPassMode = JsonRpcParamsPassMode.ARRAY)
+		@JsonRpcFixedParam(name = "param1", value = "value1")
+		void fixedParamPassParamsArray(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
+		@JsonRpcMethod(value = "fixedParamsPassParamsArray", paramsPassMode = JsonRpcParamsPassMode.ARRAY)
+		@JsonRpcFixedParams(fixedParams = { @JsonRpcFixedParam(name = "param1", value = "value1"),
+				@JsonRpcFixedParam(name = "param2", value = "value2") })
+		void fixedParamsPassParamsArray(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
 		@JsonRpcMethod(value = "allNamedParamsPassParamsArray", paramsPassMode = JsonRpcParamsPassMode.ARRAY)
 		void allNamedParamsPassParamsArray(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
 
@@ -160,6 +263,15 @@ public class ReflectionUtilTest {
 
 		@JsonRpcMethod(value = "someNamedParamsPassParamsObject", paramsPassMode = JsonRpcParamsPassMode.OBJECT)
 		void someNamedParamsPassParamsObject(@JsonRpcParam("one") String one, int two);
+
+		@JsonRpcMethod(value = "fixedParamPassParamsObject", paramsPassMode = JsonRpcParamsPassMode.OBJECT)
+		@JsonRpcFixedParam(name = "param1", value = "value1")
+		void fixedParamPassParamsObject(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
+
+		@JsonRpcMethod(value = "fixedParamsPassParamsObject", paramsPassMode = JsonRpcParamsPassMode.OBJECT)
+		@JsonRpcFixedParams(fixedParams = { @JsonRpcFixedParam(name = "param1", value = "value1"),
+				@JsonRpcFixedParam(name = "param2", value = "value2") })
+		void fixedParamsPassParamsObject(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);
 
 		@JsonRpcMethod(value = "allNamedParamsPassParamsObject", paramsPassMode = JsonRpcParamsPassMode.OBJECT)
 		void allNamedParamsPassParamsObject(@JsonRpcParam("one") String one, @JsonRpcParam("two") int two);


### PR DESCRIPTION
I had the need in a project to include some fixed parameters in some method requests in addition to rpc method's named parameters.

Since it may be of use for others and a simple addition to the parameter processing, I have included the needed changes in this pull request, along with tests and a documentation update.