### PR TITLE
enable keep-alive for HTTPS (static sslSocketFactory)

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcHttpClient.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.*;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
@@ -36,6 +37,7 @@ public class JsonRpcHttpClient extends JsonRpcClient implements IJsonRpcClient {
 	private int connectionTimeoutMillis = 60 * 1000;
 	private int readTimeoutMillis = 60 * 1000 * 2;
 	private SSLContext sslContext = null;
+	private SSLSocketFactory sslSocketFactory = null;
 	private HostnameVerifier hostNameVerifier = null;
 	private String contentType = JSONRPC_CONTENT_TYPE;
 	private boolean gzipRequests = false;
@@ -239,8 +241,10 @@ public class JsonRpcHttpClient extends JsonRpcClient implements IJsonRpcClient {
 			if (hostNameVerifier != null) {
 				https.setHostnameVerifier(hostNameVerifier);
 			}
-			if (sslContext != null) {
+			if (sslContext  != null) {
 				https.setSSLSocketFactory(sslContext.getSocketFactory());
+			} else if (sslSocketFactory != null) {
+				https.setSSLSocketFactory(sslSocketFactory);
 			}
 		}
 	}
@@ -331,6 +335,13 @@ public class JsonRpcHttpClient extends JsonRpcClient implements IJsonRpcClient {
 	 */
 	public void setSslContext(SSLContext sslContext) {
 		this.sslContext = sslContext;
+	}
+	
+	/**
+	 * @param sslSocketFactory the sslContext to set
+	 */
+	public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+		this.sslSocketFactory = sslSocketFactory;
 	}
 	
 	/**


### PR DESCRIPTION
During a migration from HTTP to HTTPS, we noticed that our `JsonRpcHttpClient`-based application was no longer using keep-alive connections.

After some research we found Bill Healey's answer on a [Stack Overflow post](https://stackoverflow.com/questions/9943351/httpsurlconnection-and-keep-alive), which explains why: for a connection/socket to be reused, quasi _everything_ about it must constant, including sub-objects attached to the connection.

For SSL in particular the `SSLSocketFactory` object must be the same across calls to the `HttpsUrlConnection`. This pull request implements this improvement, which yielded a huge performance boost when using SSL / HTTPS. Instead of using the existing `setSslContext()` context, one must use the new `setSslSocketFactory()` method.

The PR does not include a documentation update (could not find an adequate place where to insert) but of course we think that it would be worth it to add a warning about this.