### PR TITLE
Update build.gradle to set Automatic-Module-Name in manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,12 @@ dependencies {
 }
 
 
+jar {
+    manifest {
+       attributes 'Automatic-Module-Name': 'jsonrpc4j'
+   }
+}
+
 task documentationJar(type: Jar) {
     archiveClassifier.set("javadoc")
     from javadoc


### PR DESCRIPTION
This update allows the library to be included as an automatic module without relying implicitly on the JAR name for Java 9+