### PR TITLE
#305: Deprecate portlet-api support in the JsonRpcServer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     implementation 'net.iharder:base64:2.3.9'
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
 
-
+    // TODO: remove deprecated portlet-api when support is removed from the code
     servletSupportImplementation 'javax.portlet:portlet-api:3.0.1'
     servletSupportImplementation 'javax.servlet:javax.servlet-api:4.0.1'
 

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -74,12 +74,17 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 	}
 
 	/**
-	 * Handles a portlet request.
+	 * (Deprecated) Handles a portlet request.
+	 * <p>
+	 * Note: this method is marked for removal.
+	 * Please use {@link JsonRpcBasicServer#handleRequest(InputStream, OutputStream)} instead,
+	 * and propagate request and response data streams to it.
 	 *
 	 * @param request  the {@link ResourceRequest}
 	 * @param response the {@link ResourceResponse}
 	 * @throws IOException on error
 	 */
+	@Deprecated
 	public void handle(ResourceRequest request, ResourceResponse response) throws IOException {
 		logger.debug("Handing ResourceRequest {}", request.getMethod());
 		response.setContentType(contentType);


### PR DESCRIPTION
 #305: mark `com.googlecode.jsonrpc4j.JsonRpcServer#handle(javax.portlet.ResourceRequest, javax.portlet.ResourceResponse)` as deprecated


Added `@Deprecated` marker and wrote a comment in the Javadoc
