### PR TITLE
#306: Add support for newer jakarta.servlet.http API into JsonRpcServer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,9 @@ dependencies {
 
     servletSupportImplementation 'javax.portlet:portlet-api:3.0.1'
     servletSupportImplementation 'javax.servlet:javax.servlet-api:4.0.1'
+    // TODO: Jakarta EE 9 and jakarta.servlet-api 5.x are still compatible with Java SE 8,
+    // update jakarta.servlet-api to version 6+ when JDK baseline is increased to 11+
+    servletSupportImplementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 
     implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -87,6 +87,8 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 		OutputStream output = response.getPortletOutputStream();
 		handleRequest(input, output);
 		// fix to not flush within handleRequest() but outside so http status code can be set
+		// TODO: this logic may be changed to use handleCommon() method,
+		//  HTTP status code may be provided by the HttpStatusCodeProvider extension
 		output.flush();
 	}
 
@@ -112,7 +114,11 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 	 * @throws IOException on error
 	 */
 	public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		logger.debug("Handling HttpServletRequest {}", request);
+		handleCommon(new JavaxHttpServletRequest(request), new JavaxHttpServletResponse(response));
+	}
+
+	private void handleCommon(CommonHttpServletRequest request, CommonHttpServletResponse response) throws IOException {
+		logger.debug("Handling HttpServletRequest {}", request.unwrap());
 		response.setContentType(contentType);
 		OutputStream output = response.getOutputStream();
 		InputStream input = getRequestStream(request);
@@ -144,11 +150,11 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 		}
 	}
 
-	private InputStream getRequestStream(HttpServletRequest request) throws IOException {
+	private InputStream getRequestStream(CommonHttpServletRequest request) throws IOException {
 		InputStream input;
-		if (request.getMethod().equals("POST")) {
+		if ("POST".equals(request.getMethod())) {
 			input = request.getInputStream();
-		} else if (request.getMethod().equals("GET")) {
+		} else if ("GET".equals(request.getMethod())) {
 			input = createInputStream(request);
 		} else {
 			throw new IOException("Invalid request method, only POST and GET is supported");
@@ -156,7 +162,7 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 		return input;
 	}
 
-	private static InputStream createInputStream(HttpServletRequest request) throws IOException {
+	private static InputStream createInputStream(CommonHttpServletRequest request) throws IOException {
 		String method = request.getParameter(METHOD);
 		String id = request.getParameter(ID);
 		String params = request.getParameter(PARAMS);
@@ -171,4 +177,75 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 		this.contentType = contentType;
 	}
 
+	private interface CommonHttpServletRequest {
+		Object unwrap();
+		InputStream getInputStream() throws IOException;
+		String getMethod();
+		String getParameter(String name);
+	}
+
+	private static class JavaxHttpServletRequest implements CommonHttpServletRequest {
+
+		private final HttpServletRequest request;
+
+		private JavaxHttpServletRequest(HttpServletRequest request) {
+			this.request = request;
+		}
+
+		@Override
+		public HttpServletRequest unwrap() {
+			return this.request;
+		}
+
+		@Override
+		public InputStream getInputStream() throws IOException {
+			return this.request.getInputStream();
+		}
+
+		@Override
+		public String getMethod() {
+			return this.request.getMethod();
+		}
+
+		@Override
+		public String getParameter(String name) {
+			return this.request.getParameter(name);
+		}
+	}
+
+	private interface CommonHttpServletResponse {
+		void setContentType(String type);
+		void setStatus(int sc);
+		void setContentLength(int len);
+		OutputStream getOutputStream() throws IOException;
+	}
+
+	private static class JavaxHttpServletResponse implements CommonHttpServletResponse {
+
+		private final HttpServletResponse response;
+
+		private JavaxHttpServletResponse(HttpServletResponse response) {
+			this.response = response;
+		}
+
+		@Override
+		public void setContentType(String type) {
+			this.response.setContentType(type);
+		}
+
+		@Override
+		public void setStatus(int sc) {
+			this.response.setStatus(sc);
+		}
+
+		@Override
+		public void setContentLength(int len) {
+			this.response.setContentLength(len);
+		}
+
+		@Override
+		public OutputStream getOutputStream() throws IOException {
+			return this.response.getOutputStream();
+		}
+	}
 }

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -13,18 +13,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * A JSON-RPC request server reads JSON-RPC requests from an input stream and writes responses to an output stream.
  * Supports handler and servlet requests.
  */
-@SuppressWarnings("unused")
 public class JsonRpcServer extends JsonRpcBasicServer {
 	private static final Logger logger = LoggerFactory.getLogger(JsonRpcServer.class);
 
-	private static final String GZIP = "gzip";
 	private String contentType = JSONRPC_CONTENT_TYPE;
 
 	/**
@@ -162,7 +158,6 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 	}
 
 	private int resolveHttpStatusCode(int result) {
-		int httpStatusCode;
 		if (this.httpStatusCodeProvider != null) {
 			return this.httpStatusCodeProvider.getHttpStatusCode(result);
 		} else {

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcServer.java
@@ -114,7 +114,27 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 	 * @throws IOException on error
 	 */
 	public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		handleCommon(new JavaxHttpServletRequest(request), new JavaxHttpServletResponse(response));
+		handleCommon(
+			new JavaxHttpServletRequest(request),
+			new JavaxHttpServletResponse(response)
+		);
+	}
+
+	/**
+	 * Handles a servlet request.
+	 *
+	 * @param request  the {@link jakarta.servlet.http.HttpServletRequest}
+	 * @param response the {@link jakarta.servlet.http.HttpServletResponse}
+	 * @throws IOException on error
+	 */
+	public void handle(
+		jakarta.servlet.http.HttpServletRequest request,
+		jakarta.servlet.http.HttpServletResponse response
+	) throws IOException {
+		handleCommon(
+			new JakartaHttpServletRequest(request),
+			new JakartaHttpServletResponse(response)
+		);
 	}
 
 	private void handleCommon(CommonHttpServletRequest request, CommonHttpServletResponse response) throws IOException {
@@ -193,7 +213,36 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 		}
 
 		@Override
-		public HttpServletRequest unwrap() {
+		public Object unwrap() {
+			return this.request;
+		}
+
+		@Override
+		public InputStream getInputStream() throws IOException {
+			return this.request.getInputStream();
+		}
+
+		@Override
+		public String getMethod() {
+			return this.request.getMethod();
+		}
+
+		@Override
+		public String getParameter(String name) {
+			return this.request.getParameter(name);
+		}
+	}
+
+	private static class JakartaHttpServletRequest implements CommonHttpServletRequest {
+
+		private final jakarta.servlet.http.HttpServletRequest request;
+
+		private JakartaHttpServletRequest(jakarta.servlet.http.HttpServletRequest request) {
+			this.request = request;
+		}
+
+		@Override
+		public Object unwrap() {
 			return this.request;
 		}
 
@@ -225,6 +274,35 @@ public class JsonRpcServer extends JsonRpcBasicServer {
 		private final HttpServletResponse response;
 
 		private JavaxHttpServletResponse(HttpServletResponse response) {
+			this.response = response;
+		}
+
+		@Override
+		public void setContentType(String type) {
+			this.response.setContentType(type);
+		}
+
+		@Override
+		public void setStatus(int sc) {
+			this.response.setStatus(sc);
+		}
+
+		@Override
+		public void setContentLength(int len) {
+			this.response.setContentLength(len);
+		}
+
+		@Override
+		public OutputStream getOutputStream() throws IOException {
+			return this.response.getOutputStream();
+		}
+	}
+
+	private static class JakartaHttpServletResponse implements CommonHttpServletResponse {
+
+		private final jakarta.servlet.http.HttpServletResponse response;
+
+		private JakartaHttpServletResponse(jakarta.servlet.http.HttpServletResponse response) {
 			this.response = response;
 		}
 


### PR DESCRIPTION
#306: Add support for newer `jakarta.servlet.http` API into `JsonRpcServer`
----

Added an additional method, which accepts `jakarta.servlet.http.HttpServletRequest` and `jakarta.servlet.http.HttpServletResponse` as parameters.
Extracted common interfaces for `javax` and `jakarta` variants.

Now this can be used in the newer servlet containers and can also work with Spring Framework 6.

The drawback is that all users need to include `jakarta.servlet:jakarta.servlet-api` into their classpath.
