### PR TITLE
Remove usage of org.springframework.remoting.support.RemoteExporter #303

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ JSON-RPC).
   * HTTP Server (`HttpServletRequest` \ `HttpServletResponse`)
   * Portlet Server (`ResourceRequest` \ `ResourceResponse`)
   * Socket Server (`StreamServer`)
-  * Integration with the Spring Framework (`RemoteExporter`)
+  * Integration with the Spring Framework
   * Streaming client
   * HTTP client
   * Dynamic client proxies
@@ -66,7 +66,7 @@ that take `InputStream`s and `OutputStream`s.  Also in the library is a `JsonRpc
 which extends the `JsonRpcClient` to add HTTP support.
 
 ## Spring Framework
-jsonrpc4j provides a `RemoteExporter` to expose java services as JSON-RPC over HTTP without
+jsonrpc4j provides support for exposing java services as JSON-RPC over HTTP without
 requiring any additional work on the part of the programmer.  The following example explains
 how to use the `JsonServiceExporter` within the Spring Framework.
 
@@ -113,7 +113,9 @@ public class UserServiceImpl
 }
 ```
 
-Configure your service in spring as you would any other RemoteExporter:
+Configure your service in Spring as you would do it for any other Beans,
+and then add a reference of your service Bean into `JsonServiceExporter`
+by specifying the `service` and `serviceInterface` properties:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractCompositeJsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AbstractCompositeJsonServiceExporter.java
@@ -93,7 +93,7 @@ abstract class AbstractCompositeJsonServiceExporter implements InitializingBean,
 	 *
 	 * @throws Exception on error
 	 */
-	void exportService()
+	protected void exportService()
 			throws Exception {
 		// no-op
 	}

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceExporter.java
@@ -44,7 +44,6 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 
 	private ObjectMapper objectMapper;
 	private ErrorResolver errorResolver = null;
-	private Boolean registerTraceInterceptor;
 	private boolean backwardsCompatible = true;
 	private boolean rethrowExceptions = false;
 	private boolean allowExtraParams = false;
@@ -141,10 +140,6 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 			builder.addPropertyValue("invocationListener", invocationListener);
 		}
 
-		if (registerTraceInterceptor != null) {
-			builder.addPropertyValue("registerTraceInterceptor", registerTraceInterceptor);
-		}
-
 		if (httpStatusCodeProvider != null) {
 			builder.addPropertyValue("httpStatusCodeProvider", httpStatusCodeProvider);
 		}
@@ -225,12 +220,16 @@ public class AutoJsonRpcServiceExporter implements BeanFactoryPostProcessor {
 	}
 
 	/**
-	 * See {@link org.springframework.remoting.support.RemoteExporter#setRegisterTraceInterceptor(boolean)}
+	 * See {@code org.springframework.remoting.support.RemoteExporter#setRegisterTraceInterceptor(boolean)}
+	 * <p>
+	 * Note: this method is deprecated and marked for removal.
+	 * {@code RemoteExporter} and {@code TraceInterceptor-s} are no longer supported.
 	 *
 	 * @param registerTraceInterceptor the registerTraceInterceptor value to set
 	 */
+	@Deprecated
 	public void setRegisterTraceInterceptor(boolean registerTraceInterceptor) {
-		this.registerTraceInterceptor = registerTraceInterceptor;
+		// NOOP
 	}
 
 	/**

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/AutoJsonRpcServiceImplExporter.java
@@ -50,7 +50,6 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 
 	private ObjectMapper objectMapper;
 	private ErrorResolver errorResolver = null;
-	private Boolean registerTraceInterceptor;
 	private boolean backwardsCompatible = true;
 	private boolean rethrowExceptions = false;
 	private boolean allowExtraParams = false;
@@ -181,11 +180,7 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 		if (invocationListener != null) {
 			builder.addPropertyValue("invocationListener", invocationListener);
 		}
-		
-		if (registerTraceInterceptor != null) {
-			builder.addPropertyValue("registerTraceInterceptor", registerTraceInterceptor);
-		}
-		
+
 		if (httpStatusCodeProvider != null) {
 			builder.addPropertyValue("httpStatusCodeProvider", httpStatusCodeProvider);
 		}
@@ -280,14 +275,18 @@ public class AutoJsonRpcServiceImplExporter implements BeanFactoryPostProcessor 
 	public void setAllowLessParams(boolean allowLessParams) {
 		this.allowLessParams = allowLessParams;
 	}
-	
+
 	/**
-	 * See {@link org.springframework.remoting.support.RemoteExporter#setRegisterTraceInterceptor(boolean)}
+	 * See {@code org.springframework.remoting.support.RemoteExporter#setRegisterTraceInterceptor(boolean)}
+	 * <p>
+	 * Note: this method is deprecated and marked for removal.
+	 * {@code RemoteExporter} and {@code TraceInterceptor-s} are no longer supported.
 	 *
 	 * @param registerTraceInterceptor the registerTraceInterceptor value to set
 	 */
+	@Deprecated
 	public void setRegisterTraceInterceptor(boolean registerTraceInterceptor) {
-		this.registerTraceInterceptor = registerTraceInterceptor;
+		// NOOP
 	}
 	
 	/**

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/JsonServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/JsonServiceExporter.java
@@ -9,10 +9,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
- * {@link HttpRequestHandler} that exports services using Json
- * according to the JSON-RPC proposal specified at:
- * <a href="http://groups.google.com/group/json-rpc">
- * http://groups.google.com/group/json-rpc</a>.
+ * {@link HttpRequestHandler} that exports user services using JSON-RPC over HTTP protocol
  */
 public class JsonServiceExporter extends AbstractJsonServiceExporter implements HttpRequestHandler {
 

--- a/src/main/java/com/googlecode/jsonrpc4j/spring/JsonStreamServiceExporter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/JsonStreamServiceExporter.java
@@ -11,11 +11,7 @@ import static com.googlecode.jsonrpc4j.Util.DEFAULT_HOSTNAME;
 
 
 /**
- * {@link org.springframework.remoting.support.RemoteExporter RemoteExporter}
- * that exports services using Json according to the JSON-RPC proposal specified
- * at:
- * <a href="http://groups.google.com/group/json-rpc">
- * http://groups.google.com/group/json-rpc</a>.
+ * Exports user defined services as streaming server, which provides JSON-RPC over sockets.
  */
 @SuppressWarnings("unused")
 public class JsonStreamServiceExporter extends AbstractJsonServiceExporter implements DisposableBean {

--- a/src/test/java/com/googlecode/jsonrpc4j/spring/JsonServiceExporterIntegrationTest.java
+++ b/src/test/java/com/googlecode/jsonrpc4j/spring/JsonServiceExporterIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.googlecode.jsonrpc4j.spring;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.googlecode.jsonrpc4j.spring.service.Service;
+import com.googlecode.jsonrpc4j.spring.service.ServiceImpl;
+
+import static org.junit.Assert.*;
+
+/**
+ * This test ensures that {@link com.googlecode.jsonrpc4j.spring.JsonServiceExporter} bean is
+ * constructed according to Spring Framework configuration.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:serverApplicationContextC.xml")
+public class JsonServiceExporterIntegrationTest {
+
+	private static final String BEAN_NAME_AND_URL_PATH = "/UserService.json";
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	public void testExportedService() {
+		assertNotNull(applicationContext);
+
+		// check that the bean was only exported on the configured path.
+		{
+			Object bean = applicationContext.getBean(BEAN_NAME_AND_URL_PATH);
+			assertEquals(JsonServiceExporter.class, bean.getClass());
+
+			String[] names = applicationContext.getBeanNamesForType(JsonServiceExporter.class);
+			assertNotNull(names);
+			assertEquals(1, names.length);
+			assertEquals(BEAN_NAME_AND_URL_PATH, names[0]);
+		}
+
+		// check that service classes were also successfully configured in the context.
+
+		{
+			Service service = applicationContext.getBean(Service.class);
+			assertTrue(service instanceof ServiceImpl);
+
+			ServiceImpl serviceImpl = applicationContext.getBean(ServiceImpl.class);
+			assertNotNull(serviceImpl);
+		}
+	}
+}

--- a/src/test/resources/serverApplicationContextC.xml
+++ b/src/test/resources/serverApplicationContextC.xml
@@ -1,0 +1,14 @@
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <bean class="org.springframework.web.servlet.handler.BeanNameUrlHandlerMapping"/>
+
+    <bean id="userService" class="com.googlecode.jsonrpc4j.spring.service.ServiceImpl">
+    </bean>
+
+    <bean name="/UserService.json" class="com.googlecode.jsonrpc4j.spring.JsonServiceExporter">
+        <property name="service" ref="userService"/>
+        <property name="serviceInterface" value="com.googlecode.jsonrpc4j.spring.service.Service"/>
+    </bean>
+</beans>


### PR DESCRIPTION
Remove usage of `org.springframework.remoting.support.RemoteExporter` #303
----

`RemoteExporter`  was used mostly as data holder for `service` and `serviceInterface` properties.
Remoting support was removed from Spring Framework 6 and Spring does not provide this class anymore.

This change moves required `service` and `serviceInterface`  fields from `RemoteExporter` into `AbstractJsonServiceExporter` and removes usage of `RemoteExporter`.
(See also comment https://github.com/briandilley/jsonrpc4j/issues/303#issuecomment-1449771543)
Other bean registration logic was not changed.

This new version may fail for the users who inherited from the `AbstractJsonServiceExporter` class or its descendants,
and directly use any functionality inherited from  `RemoteExporter`.

I tested this with Spring Framework 6 and there were no class loading related problems in my env.


