### PR TITLE
Improve @WebParam class loading in JsonRpcBasicServer

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -134,18 +134,20 @@ public class JsonRpcBasicServer {
 	private static void loadAnnotationSupportEngine() {
 		final ClassLoader classLoader = JsonRpcBasicServer.class.getClassLoader();
 		try {
-			WEB_PARAM_ANNOTATION_CLASS = classLoader.loadClass(WEB_PARAM_ANNOTATION_CLASS_LOADER).asSubclass(Annotation.class);
+			// javax.jws.WebParam class is part of JDK in Java 1.8, and it is always present.
+			// If Jakarta variant is present in classpath, then needs to be loaded first,
+			// otherwise it will be overridden with javax.jws.WebParam from JDK 1.8
+			WEB_PARAM_ANNOTATION_CLASS = classLoader.loadClass(WEB_PARAM_ANNOTATION_CLASS_LOADER_JAKARTA).asSubclass(Annotation.class);
 			WEB_PARAM_NAME_METHOD = WEB_PARAM_ANNOTATION_CLASS.getMethod(NAME);
 		} catch (ClassNotFoundException | NoSuchMethodException e) {
-            logger.debug("Could not find {}.{}", WEB_PARAM_ANNOTATION_CLASS_LOADER, NAME);
-            logger.debug("Try to load it from jakarta package");
+            logger.debug("Could not find {}.{}", WEB_PARAM_ANNOTATION_CLASS_LOADER_JAKARTA, NAME);
+            logger.debug("Try to load it from javax package");
             try {
-                WEB_PARAM_ANNOTATION_CLASS = classLoader.loadClass(WEB_PARAM_ANNOTATION_CLASS_LOADER_JAKARTA).asSubclass(Annotation.class);
-                WEB_PARAM_NAME_METHOD = WEB_PARAM_ANNOTATION_CLASS.getMethod(NAME);
+				WEB_PARAM_ANNOTATION_CLASS = classLoader.loadClass(WEB_PARAM_ANNOTATION_CLASS_LOADER).asSubclass(Annotation.class);
+				WEB_PARAM_NAME_METHOD = WEB_PARAM_ANNOTATION_CLASS.getMethod(NAME);
             } catch (ClassNotFoundException | NoSuchMethodException ex) {
-                logger.debug("Could not find {}.{}", WEB_PARAM_ANNOTATION_CLASS_LOADER_JAKARTA, NAME);
+                logger.debug("Could not find {}.{}", WEB_PARAM_ANNOTATION_CLASS_LOADER, NAME);
             }
-
 		}
 	}
 	

--- a/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/JsonRpcBasicServer.java
@@ -49,19 +49,11 @@ public class JsonRpcBasicServer {
 	public static final String EXCEPTION_TYPE_NAME = "exceptionTypeName";
 	public static final String VERSION = "2.0";
 	public static final int CODE_OK = 0;
-	public static final String WEB_PARAM_ANNOTATION_CLASS_LOADER = "javax.jws.WebParam";
-	public static final String WEB_PARAM_ANNOTATION_CLASS_LOADER_JAKARTA = "jakarta.jws.WebParam";
 	public static final String NAME = "name";
 	public static final String NULL = "null";
 	private static final Logger logger = LoggerFactory.getLogger(JsonRpcBasicServer.class);
 	private static final ErrorResolver DEFAULT_ERROR_RESOLVER = new MultipleErrorResolver(AnnotationsErrorResolver.INSTANCE, DefaultErrorResolver.INSTANCE);
 	private static final Pattern BASE64_PATTERN = Pattern.compile("[A-Za-z0-9_=-]+");
-	private static Class<? extends Annotation> WEB_PARAM_ANNOTATION_CLASS;
-	private static Method WEB_PARAM_NAME_METHOD;
-	
-	static {
-		loadAnnotationSupportEngine();
-	}
 	
 	private final ObjectMapper mapper;
 	private final Class<?> remoteInterface;
@@ -79,6 +71,7 @@ public class JsonRpcBasicServer {
 	private List<JsonRpcInterceptor> interceptorList = new ArrayList<>();
     private ExecutorService batchExecutorService = null;
     private long parallelBatchProcessingTimeout = Long.MAX_VALUE;
+	private final Set<Class<? extends Annotation>> webParamAnnotationClasses;
 
 	/**
 	 * Creates the server with the given {@link ObjectMapper} delegating
@@ -104,6 +97,7 @@ public class JsonRpcBasicServer {
 		this.mapper = mapper;
 		this.handler = handler;
 		this.remoteInterface = remoteInterface;
+		this.webParamAnnotationClasses = loadWebParamAnnotationClasses();
 		if (handler != null) {
 			logger.debug("created server for interface {} with handler {}", remoteInterface, handler.getClass());
 		}
@@ -131,24 +125,31 @@ public class JsonRpcBasicServer {
 		this(new ObjectMapper(), handler, null);
 	}
 	
-	private static void loadAnnotationSupportEngine() {
+	private Set<Class<? extends Annotation>> loadWebParamAnnotationClasses() {
 		final ClassLoader classLoader = JsonRpcBasicServer.class.getClassLoader();
-		try {
-			// javax.jws.WebParam class is part of JDK in Java 1.8, and it is always present.
-			// If Jakarta variant is present in classpath, then needs to be loaded first,
-			// otherwise it will be overridden with javax.jws.WebParam from JDK 1.8
-			WEB_PARAM_ANNOTATION_CLASS = classLoader.loadClass(WEB_PARAM_ANNOTATION_CLASS_LOADER_JAKARTA).asSubclass(Annotation.class);
-			WEB_PARAM_NAME_METHOD = WEB_PARAM_ANNOTATION_CLASS.getMethod(NAME);
-		} catch (ClassNotFoundException | NoSuchMethodException e) {
-            logger.debug("Could not find {}.{}", WEB_PARAM_ANNOTATION_CLASS_LOADER_JAKARTA, NAME);
-            logger.debug("Try to load it from javax package");
-            try {
-				WEB_PARAM_ANNOTATION_CLASS = classLoader.loadClass(WEB_PARAM_ANNOTATION_CLASS_LOADER).asSubclass(Annotation.class);
-				WEB_PARAM_NAME_METHOD = WEB_PARAM_ANNOTATION_CLASS.getMethod(NAME);
-            } catch (ClassNotFoundException | NoSuchMethodException ex) {
-                logger.debug("Could not find {}.{}", WEB_PARAM_ANNOTATION_CLASS_LOADER, NAME);
-            }
+		Set<Class<? extends Annotation>> webParamClasses = new HashSet<>(2);
+		for (String className: Arrays.asList("javax.jws.WebParam", "jakarta.jws.WebParam")) {
+			try {
+				Class<? extends Annotation> clazz =
+					classLoader
+						.loadClass(className)
+						.asSubclass(Annotation.class);
+				// check that method with name "name" is present
+				clazz.getMethod(NAME);
+				webParamClasses.add(clazz);
+			} catch (ClassNotFoundException | NoSuchMethodException e) {
+				logger.debug("Could not find {}.{}", className, NAME);
+			}
 		}
+
+		if (webParamClasses.isEmpty()) {
+			logger.debug(
+				"Could not find any @WebParam classes in classpath." +
+					" @WebParam support is disabled"
+			);
+		}
+
+		return Collections.unmodifiableSet(webParamClasses);
 	}
 	
 	/**
@@ -1299,11 +1300,14 @@ public class JsonRpcBasicServer {
 			return parameterNames;
 		}
 		
-		private List<? extends List<? extends Annotation>> getWebParameterAnnotations(Method method) {
-			if (WEB_PARAM_ANNOTATION_CLASS == null) {
-				return new ArrayList<>();
+		private List<List<? extends Annotation>> getWebParameterAnnotations(Method method) {
+			List<List<? extends Annotation>> annotations = new ArrayList<>();
+			for (Class<? extends Annotation> clazz : JsonRpcBasicServer.this.webParamAnnotationClasses) {
+				annotations.addAll(
+					ReflectionUtil.getParameterAnnotations(method, clazz)
+				);
 			}
-			return ReflectionUtil.getParameterAnnotations(method, WEB_PARAM_ANNOTATION_CLASS);
+			return annotations;
 		}
 		
 		private JsonRpcParam createNewJsonRcpParamType(final Annotation annotation) {
@@ -1314,7 +1318,8 @@ public class JsonRpcBasicServer {
 				
 				public String value() {
 					try {
-						return (String) WEB_PARAM_NAME_METHOD.invoke(annotation);
+						Method method = annotation.getClass().getMethod(NAME);
+						return (String) method.invoke(annotation);
 					} catch (Exception e) {
 						throw new RuntimeException(e);
 					}


### PR DESCRIPTION
Improve @WebParam class loading in JsonRpcBasicServer
----

`javax.jws.WebParam` class is part of JDK in Java 1.8, and it is always present.
If Jakarta variant is also present in classpath, then needs to be loaded first,
otherwise it will be overridden by `javax.jws.WebParam` from JDK 1.8.
Tests are successful when JDK 11+  is used, because `javax.jws.WebParam`  is no longer present by default,
and proper class is loaded.

There may be applications where both `javax.jws.WebParam` and `jakarta.jws.WebParam`  are present.
This new implementation tries to load both classes and use them in the detection of method parameters.
This means that older code, which uses `javax.jws.WebParam`, should be fine even if application has newer dependency versions, where `jakarta.jws.WebParam` is also included. 
When JDK 11+ is used and there are  `jakarta.jws.WebParam` annotated parameters present in the application,
then a jar containing `javax.jws.WebParam` class should be explicitly included into classpath.


This probably fixes problems in issue #310
Test issues in #310 can be reproduced with JDK 1.8.
