### PR TITLE
use a different method to obtain the HTTP status code in the JsonRpcRestClient

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcRestClient.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/rest/JsonRpcRestClient.java
@@ -216,14 +216,15 @@ public class JsonRpcRestClient extends JsonRpcClient implements IJsonRpcClient {
 		try {
 			response = this.restTemplate.postForObject(serviceUrl.get().toExternalForm(), requestHttpEntity, ObjectNode.class);
 		} catch (HttpStatusCodeException httpStatusCodeException) {
-			logger.error("HTTP Error code={} status={}\nresponse={}"
-					, httpStatusCodeException.getStatusCode().value()
-					, httpStatusCodeException.getStatusText()
-					, httpStatusCodeException.getResponseBodyAsString()
+            int statusCode = httpStatusCodeException.getRawStatusCode();
+            logger.error("HTTP Error code={} status={}\nresponse={}",
+                statusCode,
+                httpStatusCodeException.getStatusText(),
+                httpStatusCodeException.getResponseBodyAsString()
 			);
-			Integer jsonErrorCode = DefaultHttpStatusCodeProvider.INSTANCE.getJsonRpcCode(httpStatusCodeException.getStatusCode().value());
+			Integer jsonErrorCode = DefaultHttpStatusCodeProvider.INSTANCE.getJsonRpcCode(statusCode);
 			if (jsonErrorCode == null) {
-				jsonErrorCode = httpStatusCodeException.getStatusCode().value();
+				jsonErrorCode = statusCode;
 			}
 			throw new JsonRpcClientException(jsonErrorCode, httpStatusCodeException.getStatusText(), null);
 		} catch (HttpMessageConversionException httpMessageConversionException) {


### PR DESCRIPTION
`HttpStatusCodeException.getStatusCode()` has been moved in spring-web v6 into parent class `RestClientResponseException`.

This causes missing methods errors if code is compiled with spring-web v5, but is running with spring-web v6.
```java
java.lang.NoSuchMethodError: 'org.springframework.http.HttpStatus org.springframework.web.client.HttpStatusCodeException.getStatusCode()'
                at com.googlecode.jsonrpc4j.spring.rest.JsonRpcRestClient.invoke(JsonRpcRestClient.java:220)
                at com.googlecode.jsonrpc4j.ProxyUtil$3.invoke(ProxyUtil.java:213)
               ....
```

Method [`RestClientResponseException.getRawStatusCode()`](https://docs.spring.io/spring-framework/docs/6.0.0/javadoc-api/org/springframework/web/client/RestClientResponseException.html#getRawStatusCode())  is present in both spring-web versions, but it is deprecated in spring-web v6. When jsonrpc4j code migrates to spring-web v6 or higher, then this place will need to migrate back to the `getStatusCode()` method.